### PR TITLE
Use enum for meal type

### DIFF
--- a/lib/core/data/data_source/intake_data_source.dart
+++ b/lib/core/data/data_source/intake_data_source.dart
@@ -4,6 +4,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
 
 class IntakeDataSource {
   final log = Logger('IntakeDataSource');
@@ -54,7 +55,8 @@ class IntakeDataSource {
 
   Future<List<IntakeDBO>> getIntakeRecipe() async {
     return _intakeBox.values
-        .where((intake) => intake.meal.nutriments.mealOrRecipe == "recipe")
+        .where((intake) =>
+            intake.meal.nutriments.mealOrRecipe == MealOrRecipeDBO.recipe)
         .toList();
   }
 

--- a/lib/core/data/dbo/meal_nutriments_dbo.dart
+++ b/lib/core/data/dbo/meal_nutriments_dbo.dart
@@ -1,6 +1,7 @@
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
 
 part 'meal_nutriments_dbo.g.dart';
 
@@ -22,7 +23,7 @@ class MealNutrimentsDBO extends HiveObject {
   @HiveField(6)
   final double? fiberPerQuantity;
   @HiveField(7)
-  final String? mealOrRecipe;
+  final MealOrRecipeDBO mealOrRecipe;
 
   MealNutrimentsDBO(
       {required this.energyKcalPerQuantity,
@@ -44,7 +45,8 @@ class MealNutrimentsDBO extends HiveObject {
         sugarsPerQuantity: nutriments.sugarsPerQuantity,
         saturatedFatPerQuantity: nutriments.saturatedFatPerQuantity,
         fiberPerQuantity: nutriments.fiberPerQuantity,
-        mealOrRecipe: nutriments.mealOrRecipe);
+        mealOrRecipe:
+            MealOrRecipeDBO.fromMealOrRecipeEntity(nutriments.mealOrRecipe));
   }
 
   factory MealNutrimentsDBO.fromJson(Map<String, dynamic> json) =>

--- a/lib/core/data/dbo/meal_nutriments_dbo.g.dart
+++ b/lib/core/data/dbo/meal_nutriments_dbo.g.dart
@@ -24,7 +24,7 @@ class MealNutrimentsDBOAdapter extends TypeAdapter<MealNutrimentsDBO> {
       sugarsPerQuantity: fields[4] as double?,
       saturatedFatPerQuantity: fields[5] as double?,
       fiberPerQuantity: fields[6] as double?,
-      mealOrRecipe: fields[7] as String?,
+      mealOrRecipe: fields[7] as MealOrRecipeDBO,
     );
   }
 
@@ -77,7 +77,8 @@ MealNutrimentsDBO _$MealNutrimentsDBOFromJson(Map<String, dynamic> json) =>
       saturatedFatPerQuantity:
           (json['saturatedFatPerQuantity'] as num?)?.toDouble(),
       fiberPerQuantity: (json['fiberPerQuantity'] as num?)?.toDouble(),
-      mealOrRecipe: json['mealOrRecipe'] as String?,
+      mealOrRecipe:
+          $enumDecode(_$MealOrRecipeDBOEnumMap, json['mealOrRecipe']),
     );
 
 Map<String, dynamic> _$MealNutrimentsDBOToJson(MealNutrimentsDBO instance) =>
@@ -89,5 +90,10 @@ Map<String, dynamic> _$MealNutrimentsDBOToJson(MealNutrimentsDBO instance) =>
       'sugarsPerQuantity': instance.sugarsPerQuantity,
       'saturatedFatPerQuantity': instance.saturatedFatPerQuantity,
       'fiberPerQuantity': instance.fiberPerQuantity,
-      'mealOrRecipe': instance.mealOrRecipe,
+      'mealOrRecipe': _$MealOrRecipeDBOEnumMap[instance.mealOrRecipe]!,
     };
+
+const _$MealOrRecipeDBOEnumMap = {
+  MealOrRecipeDBO.meal: 'meal',
+  MealOrRecipeDBO.recipe: 'recipe',
+};

--- a/lib/core/data/dbo/meal_or_recipe_dbo.dart
+++ b/lib/core/data/dbo/meal_or_recipe_dbo.dart
@@ -1,0 +1,21 @@
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
+
+part 'meal_or_recipe_dbo.g.dart';
+
+@HiveType(typeId: 18)
+enum MealOrRecipeDBO {
+  @HiveField(0)
+  meal,
+  @HiveField(1)
+  recipe;
+
+  factory MealOrRecipeDBO.fromMealOrRecipeEntity(MealOrRecipeEntity entity) {
+    switch (entity) {
+      case MealOrRecipeEntity.meal:
+        return MealOrRecipeDBO.meal;
+      case MealOrRecipeEntity.recipe:
+        return MealOrRecipeDBO.recipe;
+    }
+  }
+}

--- a/lib/core/data/dbo/meal_or_recipe_dbo.g.dart
+++ b/lib/core/data/dbo/meal_or_recipe_dbo.g.dart
@@ -1,0 +1,42 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'meal_or_recipe_dbo.dart';
+
+class MealOrRecipeDBOAdapter extends TypeAdapter<MealOrRecipeDBO> {
+  @override
+  final int typeId = 18;
+
+  @override
+  MealOrRecipeDBO read(BinaryReader reader) {
+    switch (reader.readByte()) {
+      case 0:
+        return MealOrRecipeDBO.meal;
+      case 1:
+        return MealOrRecipeDBO.recipe;
+      default:
+        return MealOrRecipeDBO.meal;
+    }
+  }
+
+  @override
+  void write(BinaryWriter writer, MealOrRecipeDBO obj) {
+    switch (obj) {
+      case MealOrRecipeDBO.meal:
+        writer.writeByte(0);
+        break;
+      case MealOrRecipeDBO.recipe:
+        writer.writeByte(1);
+        break;
+    }
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MealOrRecipeDBOAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/core/presentation/widgets/add_item_bottom_sheet.dart
+++ b/lib/core/presentation/widgets/add_item_bottom_sheet.dart
@@ -4,6 +4,7 @@ import 'package:opennutritracker/core/domain/entity/user_activity_entity.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/add_activity/presentation/add_activity_screen.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_screen.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
@@ -179,12 +180,14 @@ class AddItemBottomSheet extends StatelessWidget {
 
   void _showAddItemScreen(BuildContext context, AddMealType itemType) {
     Navigator.of(context).pop(); // Close bottom sheet
-    Navigator.of(context).pushNamed(NavigationOptions.addMealRoute,
-        arguments: AddMealScreenArguments(
-          itemType,
-          day,
-          "meal",
-        ));
+    Navigator.of(context).pushNamed(
+      NavigationOptions.addMealRoute,
+      arguments: AddMealScreenArguments(
+        itemType,
+        day,
+        MealOrRecipeEntity.meal,
+      ),
+    );
   }
 
   void _showAddActivityScreen(BuildContext context) {

--- a/lib/core/presentation/widgets/intake_card.dart
+++ b/lib/core/presentation/widgets/intake_card.dart
@@ -3,6 +3,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/core/presentation/widgets/meal_value_unit_text.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'dart:io';
@@ -47,7 +48,7 @@ class IntakeCard extends StatelessWidget {
               child: Stack(
                 children: [
                   intake.meal.mainImageUrl != null
-                      ? intake.meal.mealOrRecipe == "recipe"
+                      ? intake.meal.mealOrRecipe == MealOrRecipeEntity.recipe
                           ? Container(
                               decoration: BoxDecoration(
                                 image: DecorationImage(

--- a/lib/features/add_meal/domain/entity/meal_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_entity.dart
@@ -9,6 +9,7 @@ import 'package:opennutritracker/features/add_meal/data/dto/fdc/fdc_food_dto.dar
 import 'package:opennutritracker/features/add_meal/data/dto/fdc_sp/sp_fdc_food_dto.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/off/off_product_dto.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 
 class MealEntity extends Equatable {
   static const liquidUnits = {'ml', 'l', 'dl', 'cl', 'fl oz', 'fl.oz'};
@@ -145,7 +146,7 @@ class MealEntity extends Equatable {
         source: MealSourceEntity.fdc);
   }
 
-  String? get mealOrRecipe {
+  MealOrRecipeEntity get mealOrRecipe {
     return nutriments.mealOrRecipe;
   }
 

--- a/lib/features/add_meal/domain/entity/meal_nutriments_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_nutriments_entity.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/core/utils/extensions.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/fdc/fdc_const.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/fdc/fdc_food_nutriment_dto.dart';
@@ -15,7 +16,7 @@ class MealNutrimentsEntity extends Equatable {
   final double? sugarsPerQuantity;
   final double? saturatedFatPerQuantity;
   final double? fiberPerQuantity;
-  final String? mealOrRecipe;
+  final MealOrRecipeEntity mealOrRecipe;
 
   double? get energyPerUnit => _getValuePerUnit(energyKcalPerQuantity);
 
@@ -44,7 +45,7 @@ class MealNutrimentsEntity extends Equatable {
       sugarsPerQuantity: null,
       saturatedFatPerQuantity: null,
       fiberPerQuantity: null,
-      mealOrRecipe: "meal");
+      mealOrRecipe: MealOrRecipeEntity.meal);
 
   factory MealNutrimentsEntity.fromMealNutrimentsDBO(
       MealNutrimentsDBO nutriments) {
@@ -56,7 +57,8 @@ class MealNutrimentsEntity extends Equatable {
         sugarsPerQuantity: nutriments.sugarsPerQuantity,
         saturatedFatPerQuantity: nutriments.saturatedFatPerQuantity,
         fiberPerQuantity: nutriments.fiberPerQuantity,
-        mealOrRecipe: nutriments.mealOrRecipe);
+        mealOrRecipe:
+            MealOrRecipeEntity.fromMealOrRecipeDBO(nutriments.mealOrRecipe));
   }
 
   factory MealNutrimentsEntity.fromOffNutriments(
@@ -78,7 +80,7 @@ class MealNutrimentsEntity extends Equatable {
             (offNutriments.saturated_fat_100g as Object?).asDoubleOrNull(),
         fiberPerQuantity:
             (offNutriments.fiber_100g as Object?).asDoubleOrNull(),
-        mealOrRecipe: "meal");
+        mealOrRecipe: MealOrRecipeEntity.meal);
   }
 
   factory MealNutrimentsEntity.fromFDCNutriments(
@@ -136,11 +138,11 @@ class MealNutrimentsEntity extends Equatable {
         sugarsPerQuantity: sugarTotal,
         saturatedFatPerQuantity: saturatedFatTotal,
         fiberPerQuantity: fiberTotal,
-        mealOrRecipe: "meal");
+        mealOrRecipe: MealOrRecipeEntity.meal);
   }
 
   double? _getValuePerUnit(double? valuePerPerQuantity) {
-    if (mealOrRecipe == "recipe" && valuePerPerQuantity != null) {
+    if (mealOrRecipe == MealOrRecipeEntity.recipe && valuePerPerQuantity != null) {
       return valuePerPerQuantity;
     } else if (valuePerPerQuantity != null) {
       return valuePerPerQuantity / 100;

--- a/lib/features/add_meal/domain/entity/meal_or_recipe_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_or_recipe_entity.dart
@@ -1,0 +1,15 @@
+import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
+
+enum MealOrRecipeEntity {
+  meal,
+  recipe;
+
+  factory MealOrRecipeEntity.fromMealOrRecipeDBO(MealOrRecipeDBO dbo) {
+    switch (dbo) {
+      case MealOrRecipeDBO.meal:
+        return MealOrRecipeEntity.meal;
+      case MealOrRecipeDBO.recipe:
+        return MealOrRecipeEntity.recipe;
+    }
+  }
+}

--- a/lib/features/add_meal/presentation/add_meal_screen.dart
+++ b/lib/features/add_meal/presentation/add_meal_screen.dart
@@ -4,6 +4,7 @@ import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/features/add_meal/presentation/recipe_results_list.dart';
 import 'package:opennutritracker/features/add_meal/presentation/bloc/add_meal_bloc.dart';
 import 'package:opennutritracker/features/add_meal/presentation/bloc/food_bloc.dart';
@@ -33,7 +34,7 @@ class _AddMealScreenState extends State<AddMealScreen>
 
   late AddMealType _mealType;
   late DateTime _day;
-  late String _mealOrRecipe;
+  late MealOrRecipeEntity _mealOrRecipe;
 
   late ProductsBloc _productsBloc;
   late FoodBloc _foodBloc;
@@ -76,8 +77,8 @@ class _AddMealScreenState extends State<AddMealScreen>
   Widget build(BuildContext context) {
     return Scaffold(
         appBar: AppBar(
-          title: Text(
-              _mealOrRecipe == "recipe" ? "" : _mealType.getTypeName(context)),
+          title:
+              Text(_mealOrRecipe == MealOrRecipeEntity.recipe ? "" : _mealType.getTypeName(context)),
           actions: [
             BlocBuilder<AddMealBloc, AddMealState>(
               bloc: locator<AddMealBloc>()..add(InitializeAddMealEvent()),
@@ -234,7 +235,7 @@ class _AddMealScreenState extends State<AddMealScreen>
                               final filteredMeals = isOnCreateMealScreen
                                   ? state.recentMeals
                                       .where((meal) =>
-                                          meal.mealOrRecipe != 'recipe')
+                                          meal.mealOrRecipe != MealOrRecipeEntity.recipe)
                                       .toList()
                                   : state.recentMeals;
 
@@ -344,7 +345,7 @@ class _AddMealScreenState extends State<AddMealScreen>
 class AddMealScreenArguments {
   final AddMealType mealType;
   final DateTime day;
-  final String mealOrRecipe;
+  final MealOrRecipeEntity mealOrRecipe;
 
   AddMealScreenArguments(this.mealType, this.day, this.mealOrRecipe);
 }

--- a/lib/features/add_meal/presentation/widgets/meal_item_card.dart
+++ b/lib/features/add_meal/presentation/widgets/meal_item_card.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.dart';
 import 'package:opennutritracker/features/meal_detail/meal_detail_screen.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'dart:io';
 
 class MealItemCard extends StatelessWidget {
@@ -36,7 +37,7 @@ class MealItemCard extends StatelessWidget {
           height: 100,
           child: Center(
               child: ListTile(
-            leading: mealEntity.mealOrRecipe == "recipe" &&
+            leading: mealEntity.mealOrRecipe == MealOrRecipeEntity.recipe &&
                     mealEntity.thumbnailImageUrl != null
                 ? ClipRRect(
                     borderRadius: BorderRadius.circular(16),

--- a/lib/features/create_meal/create_meal_modal.dart
+++ b/lib/features/create_meal/create_meal_modal.dart
@@ -9,6 +9,7 @@ import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/create_meal/presentation/bloc/create_meal_bloc.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/core/utils/id_generator.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
@@ -146,7 +147,7 @@ class _CalendarMealTypeSelectorState extends State<CalendarMealTypeSelector> {
         sugarsPerQuantity: null,
         saturatedFatPerQuantity: null,
         fiberPerQuantity: null,
-        mealOrRecipe: "recipe");
+        mealOrRecipe: MealOrRecipeEntity.recipe);
 
     final meal = MealEntity(
       code: IdGenerator.getUniqueID(),

--- a/lib/features/create_meal/create_meal_screen.dart
+++ b/lib/features/create_meal/create_meal_screen.dart
@@ -4,6 +4,7 @@ import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_screen.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/create_meal/presentation/bloc/create_meal_bloc.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
@@ -304,7 +305,7 @@ class _MealCreationScreenState extends State<MealCreationScreen> {
       arguments: AddMealScreenArguments(
         itemType,
         day,
-        "recipe",
+        MealOrRecipeEntity.recipe,
       ),
     );
   }

--- a/lib/features/create_meal/presentation/bloc/create_meal_bloc.dart
+++ b/lib/features/create_meal/presentation/bloc/create_meal_bloc.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:opennutritracker/core/domain/entity/intake_for_recipe_entity.dart';
 import 'package:opennutritracker/core/domain/usecase/get_recipe_usecase.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 import 'package:opennutritracker/core/utils/id_generator.dart';
 
@@ -50,7 +51,7 @@ class CreateMealBloc extends Bloc<CreateMealEvent, CreateMealState> {
     final quantity = double.tryParse(amountText.replaceAll(',', '.'));
     if (quantity == null) return;
 
-    if (meal.mealOrRecipe == "recipe") {
+    if (meal.mealOrRecipe == MealOrRecipeEntity.recipe) {
       final recipe = await _recipeUsecase.getRecipeById(meal.code!);
       if (recipe == null) return;
 

--- a/lib/features/home/presentation/widgets/intake_vertical_list.dart
+++ b/lib/features/home/presentation/widgets/intake_vertical_list.dart
@@ -9,6 +9,7 @@ import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/core/utils/vertical_list_popup_menu_selections.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_screen.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
@@ -218,9 +219,15 @@ class _IntakeVerticalListState extends State<IntakeVerticalList> {
   }
 
   void _onPlaceholderCardTapped(BuildContext context) {
-    Navigator.pushNamed(context, NavigationOptions.addMealRoute,
-        arguments:
-            AddMealScreenArguments(widget.addMealType, widget.day, "meal"));
+    Navigator.pushNamed(
+      context,
+      NavigationOptions.addMealRoute,
+      arguments: AddMealScreenArguments(
+        widget.addMealType,
+        widget.day,
+        MealOrRecipeEntity.meal,
+      ),
+    );
   }
 
   void _onItemDropped(IntakeEntity entity) {

--- a/lib/features/meal_detail/meal_detail_screen.dart
+++ b/lib/features/meal_detail/meal_detail_screen.dart
@@ -9,6 +9,7 @@ import 'package:opennutritracker/core/presentation/widgets/image_full_screen.dar
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/features/create_meal/create_meal_screen.dart';
 import 'package:opennutritracker/features/edit_meal/presentation/edit_meal_screen.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
@@ -177,7 +178,7 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
                               : const SizedBox()));
             }),
             actions: [
-              if (meal.mealOrRecipe == "recipe")
+              if (meal.mealOrRecipe == MealOrRecipeEntity.recipe)
                 IconButton(
                   onPressed: () async {
                     final recipe = await locator<GetRecipeUsecase>()
@@ -234,7 +235,7 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
                     );
                   },
                   child: meal.mainImageUrl != null
-                      ? meal.mealOrRecipe == "recipe"
+                      ? meal.mealOrRecipe == MealOrRecipeEntity.recipe
                           ? Hero(
                               tag: ImageFullScreen.fullScreenHeroTag,
                               child: Container(

--- a/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
@@ -84,16 +85,14 @@ class MealDetailBottomSheet extends StatelessWidget {
                           Expanded(
                             child: DropdownButtonFormField<String>(
                               isExpanded: true,
-                              value: (product.mealOrRecipe != null &&
-                                      product.mealOrRecipe == "recipe")
+                              value: product.mealOrRecipe == MealOrRecipeEntity.recipe
                                   ? UnitDropdownItem.serving.toString()
                                   : selectedUnit,
                               decoration: InputDecoration(
                                 border: const OutlineInputBorder(),
                                 labelText: S.of(context).unitLabel,
                               ),
-                              items: (product.mealOrRecipe != null &&
-                                      product.mealOrRecipe == "recipe")
+                              items: product.mealOrRecipe == MealOrRecipeEntity.recipe
                                   ? [_getServingDropdownItem(context)]
                                   : <DropdownMenuItem<String>>[
                                       if (product.hasServingValues)

--- a/lib/features/meal_detail/presentation/widgets/meal_detail_nutriments_table.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_nutriments_table.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:opennutritracker/core/utils/extensions.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 class MealDetailNutrimentsTable extends StatelessWidget {
@@ -27,7 +28,7 @@ class MealDetailNutrimentsTable extends StatelessWidget {
         const TextStyle();
 
     final headerText = (usesImperialUnits && servingQuantity != null) ||
-            product.mealOrRecipe == "recipe"
+            product.mealOrRecipe == MealOrRecipeEntity.recipe
         ? "${S.of(context).perServingLabel} (${servingQuantity!.roundToPrecision(1)} ${servingUnit ?? 'g/ml'})"
         : S.of(context).per100gmlLabel;
 

--- a/test/fixture/intake_for_recipe_fixtures.dart
+++ b/test/fixture/intake_for_recipe_fixtures.dart
@@ -1,6 +1,7 @@
 import 'package:opennutritracker/core/domain/entity/intake_for_recipe_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 
 class IntakeForRecipeFixtures {
   static final chicken = IntakeForRecipeEntity(
@@ -25,7 +26,7 @@ class IntakeForRecipeFixtures {
         sugarsPerQuantity: 0,
         saturatedFatPerQuantity: 1,
         fiberPerQuantity: 0,
-        mealOrRecipe: 'meal',
+        mealOrRecipe: MealOrRecipeEntity.meal,
       ),
       source: MealSourceEntity.custom,
     ),
@@ -53,7 +54,7 @@ class IntakeForRecipeFixtures {
         sugarsPerQuantity: 0,
         saturatedFatPerQuantity: 0,
         fiberPerQuantity: 0,
-        mealOrRecipe: 'meal',
+        mealOrRecipe: MealOrRecipeEntity.meal,
       ),
       source: MealSourceEntity.custom,
     ),

--- a/test/fixture/recipe_entity_fixtures.dart
+++ b/test/fixture/recipe_entity_fixtures.dart
@@ -2,6 +2,7 @@ import 'package:opennutritracker/core/domain/entity/recipe_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_for_recipe_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 
 class RecipeEntityFixtures {
   static final meal = MealEntity(
@@ -24,7 +25,7 @@ class RecipeEntityFixtures {
       sugarsPerQuantity: 5,
       saturatedFatPerQuantity: 2,
       fiberPerQuantity: 4,
-      mealOrRecipe: "recipe",
+      mealOrRecipe: MealOrRecipeEntity.recipe,
     ),
     source: MealSourceEntity.custom,
   );


### PR DESCRIPTION
## Summary
- add `MealOrRecipeEntity` and `MealOrRecipeDBO` enums
- refactor meal nutriments model to use the enum
- replace string checks with enum comparisons across UI and data
- update helper screens to pass the enum when opening AddMeal screens

## Testing
- `flutter analyze` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_683f7ab1a7fc83218065e7ae713aab42