### PR TITLE
Refactor meal/recipe to enum

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,7 +36,6 @@ migrate_working_dir/
 
 # API Keys
 *.env
-env.g.dart
 
 # Symbolication related
 app.*.symbols

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,18 @@
+# Development Agents – Guidelines
+
+## Mandatory Testing
+
+Every time a change is made to the code (feature, bug fix, refactoring…), **you must run the tests** to ensure the stability of the project.
+
+### How to run the tests
+
+1. Make sure all dependencies are installed:
+
+   ```bash
+   flutter pub get
+   ```
+2. Run the tests:
+
+   ```bash
+   flutter test
+   ```

--- a/lib/core/data/data_source/intake_data_source.dart
+++ b/lib/core/data/data_source/intake_data_source.dart
@@ -4,6 +4,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
 
 class IntakeDataSource {
   final log = Logger('IntakeDataSource');
@@ -54,7 +55,7 @@ class IntakeDataSource {
 
   Future<List<IntakeDBO>> getIntakeRecipe() async {
     return _intakeBox.values
-        .where((intake) => intake.meal.nutriments.mealOrRecipe == "recipe")
+        .where((intake) => intake.meal.nutriments.mealOrRecipe == MealOrRecipeDBO.recipe)
         .toList();
   }
 

--- a/lib/core/data/dbo/meal_nutriments_dbo.dart
+++ b/lib/core/data/dbo/meal_nutriments_dbo.dart
@@ -1,6 +1,7 @@
 import 'package:hive_flutter/hive_flutter.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
 
 part 'meal_nutriments_dbo.g.dart';
 
@@ -22,7 +23,7 @@ class MealNutrimentsDBO extends HiveObject {
   @HiveField(6)
   final double? fiberPerQuantity;
   @HiveField(7)
-  final String? mealOrRecipe;
+  final MealOrRecipeDBO mealOrRecipe;
 
   MealNutrimentsDBO(
       {required this.energyKcalPerQuantity,
@@ -44,7 +45,8 @@ class MealNutrimentsDBO extends HiveObject {
         sugarsPerQuantity: nutriments.sugarsPerQuantity,
         saturatedFatPerQuantity: nutriments.saturatedFatPerQuantity,
         fiberPerQuantity: nutriments.fiberPerQuantity,
-        mealOrRecipe: nutriments.mealOrRecipe);
+        mealOrRecipe:
+            MealOrRecipeDBO.fromMealOrRecipeEntity(nutriments.mealOrRecipe));
   }
 
   factory MealNutrimentsDBO.fromJson(Map<String, dynamic> json) =>

--- a/lib/core/data/dbo/meal_nutriments_dbo.g.dart
+++ b/lib/core/data/dbo/meal_nutriments_dbo.g.dart
@@ -24,7 +24,8 @@ class MealNutrimentsDBOAdapter extends TypeAdapter<MealNutrimentsDBO> {
       sugarsPerQuantity: fields[4] as double?,
       saturatedFatPerQuantity: fields[5] as double?,
       fiberPerQuantity: fields[6] as double?,
-      mealOrRecipe: fields[7] as String?,
+      mealOrRecipe:
+          (fields[7] as MealOrRecipeDBO?) ?? MealOrRecipeDBO.meal,
     );
   }
 
@@ -77,7 +78,7 @@ MealNutrimentsDBO _$MealNutrimentsDBOFromJson(Map<String, dynamic> json) =>
       saturatedFatPerQuantity:
           (json['saturatedFatPerQuantity'] as num?)?.toDouble(),
       fiberPerQuantity: (json['fiberPerQuantity'] as num?)?.toDouble(),
-      mealOrRecipe: json['mealOrRecipe'] as String?,
+      mealOrRecipe: $enumDecode(_$MealOrRecipeDBOEnumMap, json['mealOrRecipe']),
     );
 
 Map<String, dynamic> _$MealNutrimentsDBOToJson(MealNutrimentsDBO instance) =>
@@ -89,5 +90,10 @@ Map<String, dynamic> _$MealNutrimentsDBOToJson(MealNutrimentsDBO instance) =>
       'sugarsPerQuantity': instance.sugarsPerQuantity,
       'saturatedFatPerQuantity': instance.saturatedFatPerQuantity,
       'fiberPerQuantity': instance.fiberPerQuantity,
-      'mealOrRecipe': instance.mealOrRecipe,
+      'mealOrRecipe': _$MealOrRecipeDBOEnumMap[instance.mealOrRecipe]!,
     };
+
+const _$MealOrRecipeDBOEnumMap = {
+  MealOrRecipeDBO.meal: 'meal',
+  MealOrRecipeDBO.recipe: 'recipe',
+};

--- a/lib/core/data/dbo/meal_or_recipe_dbo.dart
+++ b/lib/core/data/dbo/meal_or_recipe_dbo.dart
@@ -1,0 +1,21 @@
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
+
+part 'meal_or_recipe_dbo.g.dart';
+
+@HiveType(typeId: 2)
+enum MealOrRecipeDBO {
+  @HiveField(0)
+  meal,
+  @HiveField(1)
+  recipe;
+
+  factory MealOrRecipeDBO.fromMealOrRecipeEntity(MealOrRecipeEntity entity) {
+    switch (entity) {
+      case MealOrRecipeEntity.meal:
+        return MealOrRecipeDBO.meal;
+      case MealOrRecipeEntity.recipe:
+        return MealOrRecipeDBO.recipe;
+    }
+  }
+}

--- a/lib/core/data/dbo/meal_or_recipe_dbo.g.dart
+++ b/lib/core/data/dbo/meal_or_recipe_dbo.g.dart
@@ -1,0 +1,46 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+
+part of 'meal_or_recipe_dbo.dart';
+
+// **************************************************************************
+// TypeAdapterGenerator
+// **************************************************************************
+
+class MealOrRecipeDBOAdapter extends TypeAdapter<MealOrRecipeDBO> {
+  @override
+  final int typeId = 2;
+
+  @override
+  MealOrRecipeDBO read(BinaryReader reader) {
+    switch (reader.readByte()) {
+      case 0:
+        return MealOrRecipeDBO.meal;
+      case 1:
+        return MealOrRecipeDBO.recipe;
+      default:
+        return MealOrRecipeDBO.meal;
+    }
+  }
+
+  @override
+  void write(BinaryWriter writer, MealOrRecipeDBO obj) {
+    switch (obj) {
+      case MealOrRecipeDBO.meal:
+        writer.writeByte(0);
+        break;
+      case MealOrRecipeDBO.recipe:
+        writer.writeByte(1);
+        break;
+    }
+  }
+
+  @override
+  int get hashCode => typeId.hashCode;
+
+  @override
+  bool operator ==(Object other) =>
+      identical(this, other) ||
+      other is MealOrRecipeDBOAdapter &&
+          runtimeType == other.runtimeType &&
+          typeId == other.typeId;
+}

--- a/lib/core/presentation/widgets/intake_card.dart
+++ b/lib/core/presentation/widgets/intake_card.dart
@@ -3,6 +3,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/core/presentation/widgets/meal_value_unit_text.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'dart:io';
@@ -47,7 +48,7 @@ class IntakeCard extends StatelessWidget {
               child: Stack(
                 children: [
                   intake.meal.mainImageUrl != null
-                      ? intake.meal.mealOrRecipe == "recipe"
+                      ? intake.meal.mealOrRecipe == MealOrRecipeEntity.recipe
                           ? Container(
                               decoration: BoxDecoration(
                                 image: DecorationImage(

--- a/lib/core/utils/env.g.dart
+++ b/lib/core/utils/env.g.dart
@@ -1,0 +1,8 @@
+part of 'env.dart';
+
+class _Env {
+  static const String fdcApiKey = '';
+  static const String sentryDns = '';
+  static const String supabaseProjectUrl = '';
+  static const String supabaseProjectAnonKey = '';
+}

--- a/lib/core/utils/hive_db_provider.dart
+++ b/lib/core/utils/hive_db_provider.dart
@@ -9,6 +9,7 @@ import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_recipe_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/physical_activity_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
@@ -40,6 +41,8 @@ class HiveDBProvider extends ChangeNotifier {
     Hive.registerAdapter(IntakeDBOAdapter());
     Hive.registerAdapter(MealDBOAdapter());
     Hive.registerAdapter(IntakeForRecipeDBOAdapter());
+
+    Hive.registerAdapter(MealOrRecipeDBOAdapter());
 
     Hive.registerAdapter(MealNutrimentsDBOAdapter());
     Hive.registerAdapter(MealSourceDBOAdapter());

--- a/lib/features/add_meal/domain/entity/meal_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_entity.dart
@@ -9,6 +9,7 @@ import 'package:opennutritracker/features/add_meal/data/dto/fdc/fdc_food_dto.dar
 import 'package:opennutritracker/features/add_meal/data/dto/fdc_sp/sp_fdc_food_dto.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/off/off_product_dto.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 
 class MealEntity extends Equatable {
   static const liquidUnits = {'ml', 'l', 'dl', 'cl', 'fl oz', 'fl.oz'};
@@ -145,7 +146,7 @@ class MealEntity extends Equatable {
         source: MealSourceEntity.fdc);
   }
 
-  String? get mealOrRecipe {
+  MealOrRecipeEntity get mealOrRecipe {
     return nutriments.mealOrRecipe;
   }
 

--- a/lib/features/add_meal/domain/entity/meal_nutriments_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_nutriments_entity.dart
@@ -1,6 +1,7 @@
 import 'package:collection/collection.dart';
 import 'package:equatable/equatable.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/core/utils/extensions.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/fdc/fdc_const.dart';
 import 'package:opennutritracker/features/add_meal/data/dto/fdc/fdc_food_nutriment_dto.dart';
@@ -15,7 +16,7 @@ class MealNutrimentsEntity extends Equatable {
   final double? sugarsPerQuantity;
   final double? saturatedFatPerQuantity;
   final double? fiberPerQuantity;
-  final String? mealOrRecipe;
+  final MealOrRecipeEntity mealOrRecipe;
 
   double? get energyPerUnit => _getValuePerUnit(energyKcalPerQuantity);
 
@@ -44,7 +45,7 @@ class MealNutrimentsEntity extends Equatable {
       sugarsPerQuantity: null,
       saturatedFatPerQuantity: null,
       fiberPerQuantity: null,
-      mealOrRecipe: "meal");
+      mealOrRecipe: MealOrRecipeEntity.meal);
 
   factory MealNutrimentsEntity.fromMealNutrimentsDBO(
       MealNutrimentsDBO nutriments) {
@@ -56,7 +57,8 @@ class MealNutrimentsEntity extends Equatable {
         sugarsPerQuantity: nutriments.sugarsPerQuantity,
         saturatedFatPerQuantity: nutriments.saturatedFatPerQuantity,
         fiberPerQuantity: nutriments.fiberPerQuantity,
-        mealOrRecipe: nutriments.mealOrRecipe);
+        mealOrRecipe:
+            MealOrRecipeEntity.fromMealOrRecipeDBO(nutriments.mealOrRecipe));
   }
 
   factory MealNutrimentsEntity.fromOffNutriments(
@@ -78,7 +80,7 @@ class MealNutrimentsEntity extends Equatable {
             (offNutriments.saturated_fat_100g as Object?).asDoubleOrNull(),
         fiberPerQuantity:
             (offNutriments.fiber_100g as Object?).asDoubleOrNull(),
-        mealOrRecipe: "meal");
+        mealOrRecipe: MealOrRecipeEntity.meal);
   }
 
   factory MealNutrimentsEntity.fromFDCNutriments(
@@ -136,11 +138,11 @@ class MealNutrimentsEntity extends Equatable {
         sugarsPerQuantity: sugarTotal,
         saturatedFatPerQuantity: saturatedFatTotal,
         fiberPerQuantity: fiberTotal,
-        mealOrRecipe: "meal");
+        mealOrRecipe: MealOrRecipeEntity.meal);
   }
 
   double? _getValuePerUnit(double? valuePerPerQuantity) {
-    if (mealOrRecipe == "recipe" && valuePerPerQuantity != null) {
+    if (mealOrRecipe == MealOrRecipeEntity.recipe && valuePerPerQuantity != null) {
       return valuePerPerQuantity;
     } else if (valuePerPerQuantity != null) {
       return valuePerPerQuantity / 100;

--- a/lib/features/add_meal/domain/entity/meal_or_recipe_entity.dart
+++ b/lib/features/add_meal/domain/entity/meal_or_recipe_entity.dart
@@ -1,0 +1,15 @@
+import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
+
+enum MealOrRecipeEntity {
+  meal,
+  recipe;
+
+  factory MealOrRecipeEntity.fromMealOrRecipeDBO(MealOrRecipeDBO dbo) {
+    switch (dbo) {
+      case MealOrRecipeDBO.meal:
+        return MealOrRecipeEntity.meal;
+      case MealOrRecipeDBO.recipe:
+        return MealOrRecipeEntity.recipe;
+    }
+  }
+}

--- a/lib/features/add_meal/presentation/add_meal_screen.dart
+++ b/lib/features/add_meal/presentation/add_meal_screen.dart
@@ -3,6 +3,7 @@ import 'package:opennutritracker/core/presentation/widgets/error_dialog.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.dart';
 import 'package:opennutritracker/features/add_meal/presentation/recipe_results_list.dart';
 import 'package:opennutritracker/features/add_meal/presentation/bloc/add_meal_bloc.dart';
@@ -33,7 +34,7 @@ class _AddMealScreenState extends State<AddMealScreen>
 
   late AddMealType _mealType;
   late DateTime _day;
-  late String _mealOrRecipe;
+  late MealOrRecipeEntity _mealOrRecipe;
 
   late ProductsBloc _productsBloc;
   late FoodBloc _foodBloc;
@@ -77,7 +78,7 @@ class _AddMealScreenState extends State<AddMealScreen>
     return Scaffold(
         appBar: AppBar(
           title: Text(
-              _mealOrRecipe == "recipe" ? "" : _mealType.getTypeName(context)),
+              _mealOrRecipe == MealOrRecipeEntity.recipe ? "" : _mealType.getTypeName(context)),
           actions: [
             BlocBuilder<AddMealBloc, AddMealState>(
               bloc: locator<AddMealBloc>()..add(InitializeAddMealEvent()),
@@ -234,7 +235,7 @@ class _AddMealScreenState extends State<AddMealScreen>
                               final filteredMeals = isOnCreateMealScreen
                                   ? state.recentMeals
                                       .where((meal) =>
-                                          meal.mealOrRecipe != 'recipe')
+                                          meal.mealOrRecipe != MealOrRecipeEntity.recipe)
                                       .toList()
                                   : state.recentMeals;
 
@@ -344,7 +345,7 @@ class _AddMealScreenState extends State<AddMealScreen>
 class AddMealScreenArguments {
   final AddMealType mealType;
   final DateTime day;
-  final String mealOrRecipe;
+  final MealOrRecipeEntity mealOrRecipe;
 
   AddMealScreenArguments(this.mealType, this.day, this.mealOrRecipe);
 }

--- a/lib/features/add_meal/presentation/widgets/meal_item_card.dart
+++ b/lib/features/add_meal/presentation/widgets/meal_item_card.dart
@@ -6,6 +6,7 @@ import 'package:opennutritracker/core/presentation/widgets/meal_value_unit_text.
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.dart';
 import 'package:opennutritracker/features/meal_detail/meal_detail_screen.dart';
 import 'dart:io';
@@ -36,7 +37,7 @@ class MealItemCard extends StatelessWidget {
           height: 100,
           child: Center(
               child: ListTile(
-            leading: mealEntity.mealOrRecipe == "recipe" &&
+            leading: mealEntity.mealOrRecipe == MealOrRecipeEntity.recipe &&
                     mealEntity.thumbnailImageUrl != null
                 ? ClipRRect(
                     borderRadius: BorderRadius.circular(16),

--- a/lib/features/create_meal/create_meal_modal.dart
+++ b/lib/features/create_meal/create_meal_modal.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/generated/l10n.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/create_meal/presentation/bloc/create_meal_bloc.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/core/utils/id_generator.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
@@ -146,7 +147,7 @@ class _CalendarMealTypeSelectorState extends State<CalendarMealTypeSelector> {
         sugarsPerQuantity: null,
         saturatedFatPerQuantity: null,
         fiberPerQuantity: null,
-        mealOrRecipe: "recipe");
+        mealOrRecipe: MealOrRecipeEntity.recipe);
 
     final meal = MealEntity(
       code: IdGenerator.getUniqueID(),

--- a/lib/features/create_meal/presentation/bloc/create_meal_bloc.dart
+++ b/lib/features/create_meal/presentation/bloc/create_meal_bloc.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:opennutritracker/core/domain/entity/intake_for_recipe_entity.dart';
 import 'package:opennutritracker/core/domain/usecase/get_recipe_usecase.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 import 'package:opennutritracker/core/utils/id_generator.dart';
 
@@ -50,7 +51,7 @@ class CreateMealBloc extends Bloc<CreateMealEvent, CreateMealState> {
     final quantity = double.tryParse(amountText.replaceAll(',', '.'));
     if (quantity == null) return;
 
-    if (meal.mealOrRecipe == "recipe") {
+    if (meal.mealOrRecipe == MealOrRecipeEntity.recipe) {
       final recipe = await _recipeUsecase.getRecipeById(meal.code!);
       if (recipe == null) return;
 

--- a/lib/features/meal_detail/meal_detail_screen.dart
+++ b/lib/features/meal_detail/meal_detail_screen.dart
@@ -9,6 +9,7 @@ import 'package:opennutritracker/core/presentation/widgets/image_full_screen.dar
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/features/create_meal/create_meal_screen.dart';
 import 'package:opennutritracker/features/edit_meal/presentation/edit_meal_screen.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/bloc/meal_detail_bloc.dart';
@@ -177,7 +178,7 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
                               : const SizedBox()));
             }),
             actions: [
-              if (meal.mealOrRecipe == "recipe")
+              if (meal.mealOrRecipe == MealOrRecipeEntity.recipe)
                 IconButton(
                   onPressed: () async {
                     final recipe = await locator<GetRecipeUsecase>()
@@ -234,7 +235,7 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
                     );
                   },
                   child: meal.mainImageUrl != null
-                      ? meal.mealOrRecipe == "recipe"
+                      ? meal.mealOrRecipe == MealOrRecipeEntity.recipe
                           ? Hero(
                               tag: ImageFullScreen.fullScreenHeroTag,
                               child: Container(

--- a/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_bottom_sheet.dart
@@ -3,6 +3,7 @@ import 'package:flutter/services.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
 import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
 import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
@@ -85,7 +86,7 @@ class MealDetailBottomSheet extends StatelessWidget {
                             child: DropdownButtonFormField<String>(
                               isExpanded: true,
                               value: (product.mealOrRecipe != null &&
-                                      product.mealOrRecipe == "recipe")
+                                      product.mealOrRecipe == MealOrRecipeEntity.recipe)
                                   ? UnitDropdownItem.serving.toString()
                                   : selectedUnit,
                               decoration: InputDecoration(
@@ -93,7 +94,7 @@ class MealDetailBottomSheet extends StatelessWidget {
                                 labelText: S.of(context).unitLabel,
                               ),
                               items: (product.mealOrRecipe != null &&
-                                      product.mealOrRecipe == "recipe")
+                                      product.mealOrRecipe == MealOrRecipeEntity.recipe)
                                   ? [_getServingDropdownItem(context)]
                                   : <DropdownMenuItem<String>>[
                                       if (product.hasServingValues)

--- a/lib/features/meal_detail/presentation/widgets/meal_detail_nutriments_table.dart
+++ b/lib/features/meal_detail/presentation/widgets/meal_detail_nutriments_table.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:opennutritracker/core/utils/extensions.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 
 class MealDetailNutrimentsTable extends StatelessWidget {
@@ -27,7 +28,7 @@ class MealDetailNutrimentsTable extends StatelessWidget {
         const TextStyle();
 
     final headerText = (usesImperialUnits && servingQuantity != null) ||
-            product.mealOrRecipe == "recipe"
+            product.mealOrRecipe == MealOrRecipeEntity.recipe
         ? "${S.of(context).perServingLabel} (${servingQuantity!.roundToPrecision(1)} ${servingUnit ?? 'g/ml'})"
         : S.of(context).per100gmlLabel;
 

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -82,10 +82,10 @@ packages:
     dependency: transitive
     description:
       name: async
-      sha256: d2872f9c19731c2e5f10444b14686eb7cc85c76274bd6c16e1816bff9a3bab63
+      sha256: "758e6d74e971c3e5aceb4110bfd6698efc7f501675bcfe0c775459a8140750eb"
       url: "https://pub.dev"
     source: hosted
-    version: "2.12.0"
+    version: "2.13.0"
   auto_size_text:
     dependency: "direct main"
     description:
@@ -354,10 +354,10 @@ packages:
     dependency: transitive
     description:
       name: fake_async
-      sha256: "6a95e56b2449df2273fd8c45a662d6947ce1ebb7aafe80e550a3f68297f3cacc"
+      sha256: "5368f224a74523e8d2e7399ea1638b37aecfca824a3cc4dfdf77bf1fa905ac44"
       url: "https://pub.dev"
     source: hosted
-    version: "1.3.2"
+    version: "1.3.3"
   ffi:
     dependency: transitive
     description:
@@ -774,10 +774,10 @@ packages:
     dependency: "direct main"
     description:
       name: intl
-      sha256: d6f56758b7d3014a48af9701c085700aac781a92a87a62b1333b46d8879661cf
+      sha256: "3df61194eb431efc39c4ceba583b95633a403f46c9fd341e550ce0bfa50e9aa5"
       url: "https://pub.dev"
     source: hosted
-    version: "0.19.0"
+    version: "0.20.2"
   intl_utils:
     dependency: "direct main"
     description:
@@ -838,10 +838,10 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: c35baad643ba394b40aac41080300150a4f08fd0fd6a10378f8f7c6bc161acec
+      sha256: "6bb818ecbdffe216e81182c2f0714a2e62b593f4a4f13098713ff1685dfb6ab0"
       url: "https://pub.dev"
     source: hosted
-    version: "10.0.8"
+    version: "10.0.9"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
@@ -1443,10 +1443,10 @@ packages:
     dependency: "direct main"
     description:
       name: table_calendar
-      sha256: b2896b7c86adf3a4d9c911d860120fe3dbe03c85db43b22fd61f14ee78cdbb63
+      sha256: "0c0c6219878b363a2d5f40c7afb159d845f253d061dc3c822aa0d5fe0f721982"
       url: "https://pub.dev"
     source: hosted
-    version: "3.1.3"
+    version: "3.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -1603,10 +1603,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: "0968250880a6c5fe7edc067ed0a13d4bae1577fe2771dcf3010d52c4a9d3ca14"
+      sha256: ddfa8d30d89985b96407efce8acbdd124701f96741f2d981ca860662f1c0dc02
       url: "https://pub.dev"
     source: hosted
-    version: "14.3.1"
+    version: "15.0.0"
   watcher:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -35,7 +35,7 @@ dependencies:
   intl_utils: ^2.8.3
   collection: ^1.19.0
   image_picker: ^1.1.2
-  intl: ^0.19.0
+  intl: ^0.20.2
   get_it: ^8.0.3
   provider: ^6.1.2
   http: ^1.2.2

--- a/test/fixture/intake_for_recipe_fixtures.dart
+++ b/test/fixture/intake_for_recipe_fixtures.dart
@@ -1,6 +1,7 @@
 import 'package:opennutritracker/core/domain/entity/intake_for_recipe_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 
 class IntakeForRecipeFixtures {
   static final chicken = IntakeForRecipeEntity(
@@ -25,7 +26,7 @@ class IntakeForRecipeFixtures {
         sugarsPerQuantity: 0,
         saturatedFatPerQuantity: 1,
         fiberPerQuantity: 0,
-        mealOrRecipe: 'meal',
+        mealOrRecipe: MealOrRecipeEntity.meal,
       ),
       source: MealSourceEntity.custom,
     ),
@@ -53,7 +54,7 @@ class IntakeForRecipeFixtures {
         sugarsPerQuantity: 0,
         saturatedFatPerQuantity: 0,
         fiberPerQuantity: 0,
-        mealOrRecipe: 'meal',
+        mealOrRecipe: MealOrRecipeEntity.meal,
       ),
       source: MealSourceEntity.custom,
     ),

--- a/test/fixture/recipe_entity_fixtures.dart
+++ b/test/fixture/recipe_entity_fixtures.dart
@@ -2,6 +2,7 @@ import 'package:opennutritracker/core/domain/entity/recipe_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_for_recipe_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_nutriments_entity.dart';
+import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 
 class RecipeEntityFixtures {
   static final meal = MealEntity(
@@ -24,7 +25,7 @@ class RecipeEntityFixtures {
       sugarsPerQuantity: 5,
       saturatedFatPerQuantity: 2,
       fiberPerQuantity: 4,
-      mealOrRecipe: "recipe",
+      mealOrRecipe: MealOrRecipeEntity.recipe,
     ),
     source: MealSourceEntity.custom,
   );

--- a/test/unit_test/intake_repository_test.dart
+++ b/test/unit_test/intake_repository_test.dart
@@ -5,6 +5,7 @@ import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
 import 'package:opennutritracker/core/data/repository/intake_repository.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
@@ -23,6 +24,7 @@ void main() {
       Hive.registerAdapter(MealDBOAdapter());
       Hive.registerAdapter(MealSourceDBOAdapter());
       Hive.registerAdapter(MealNutrimentsDBOAdapter());
+      Hive.registerAdapter(MealOrRecipeDBOAdapter());
     });
 
     tearDown(() {

--- a/test/unit_test/recipe_repository_test.dart
+++ b/test/unit_test/recipe_repository_test.dart
@@ -5,6 +5,7 @@ import 'package:hive/hive.dart';
 import 'package:opennutritracker/core/data/data_source/recipe_data_source.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
 import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
@@ -31,6 +32,7 @@ void main() {
       Hive.registerAdapter(MealNutrimentsDBOAdapter());
       Hive.registerAdapter(MealSourceDBOAdapter());
       Hive.registerAdapter(IntakeForRecipeDBOAdapter());
+      Hive.registerAdapter(MealOrRecipeDBOAdapter());
 
       box = await Hive.openBox<RecipesDBO>('recipes_test');
 


### PR DESCRIPTION
## Summary
- use an enum for meal vs recipe instead of strings
- register `MealOrRecipeDBOAdapter` in tests and database provider
- tolerate missing enum values when reading older Hive data
- stub `env.g.dart` for tests and update intl to 0.20.2

## Testing
- `flutter pub get`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68404fe879c0832193c9e01ea4ba1cf0