### PR TITLE
Add Supabase Auth login screen

### DIFF
--- a/lib/core/utils/navigation_options.dart
+++ b/lib/core/utils/navigation_options.dart
@@ -11,4 +11,6 @@ class NavigationOptions {
   static const imageFullScreenRoute = "imageFullScreen";
   static const createMealRoute = 'createMeal';
   static const recipeRoute = "recipe";
+  static const loginRoute = "login";
+  static const resetPasswordRoute = "resetPassword";
 }

--- a/lib/features/auth/login_screen.dart
+++ b/lib/features/auth/login_screen.dart
@@ -1,0 +1,60 @@
+import 'package:flutter/foundation.dart';
+import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+import 'package:opennutritracker/core/utils/navigation_options.dart';
+
+class LoginScreen extends StatelessWidget {
+  const LoginScreen({super.key});
+
+  void _navigateHome(BuildContext context) {
+    Navigator.of(context).pushReplacementNamed(NavigationOptions.mainRoute);
+  }
+
+  void _showError(BuildContext context, Object error) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('$error')),
+    );
+    Logger('LoginScreen').warning('Auth error', error);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Sign In')),
+      body: SingleChildScrollView(
+        padding: const EdgeInsets.all(24),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            SupaEmailAuth(
+              redirectTo: kIsWeb ? null : 'io.supabase.flutter://login-callback/',
+              onSignInComplete: (_) => _navigateHome(context),
+              onSignUpComplete: (_) => _navigateHome(context),
+              onPasswordResetEmailSent: () {
+                ScaffoldMessenger.of(context).showSnackBar(
+                  const SnackBar(content: Text('Password reset email sent')),
+                );
+              },
+              onError: (error) => _showError(context, error),
+            ),
+            const SizedBox(height: 32),
+            SupaMagicAuth(
+              redirectUrl: kIsWeb ? null : 'io.supabase.flutter://login-callback/',
+              onSuccess: (_) => _navigateHome(context),
+              onError: (error) => _showError(context, error),
+            ),
+            const SizedBox(height: 32),
+            SupaSocialsAuth(
+              colored: true,
+              socialProviders: const [OAuthProvider.google, OAuthProvider.apple],
+              redirectUrl: kIsWeb ? null : 'io.supabase.flutter://login-callback/',
+              onSuccess: (_) => _navigateHome(context),
+              onError: (error) => _showError(context, error),
+            ),
+          ],
+        ),
+      ),
+    );
+  }
+}

--- a/lib/features/auth/reset_password_screen.dart
+++ b/lib/features/auth/reset_password_screen.dart
@@ -1,0 +1,37 @@
+import 'package:flutter/material.dart';
+import 'package:logging/logging.dart';
+import 'package:supabase_auth_ui/supabase_auth_ui.dart';
+import 'package:opennutritracker/core/utils/navigation_options.dart';
+
+class ResetPasswordScreen extends StatelessWidget {
+  const ResetPasswordScreen({super.key});
+
+  void _navigateHome(BuildContext context) {
+    Navigator.of(context).pushReplacementNamed(NavigationOptions.mainRoute);
+  }
+
+  void _showError(BuildContext context, Object error) {
+    ScaffoldMessenger.of(context).showSnackBar(
+      SnackBar(content: Text('$error')),
+    );
+    Logger('ResetPassword').warning('Password reset error', error);
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    final accessToken = Supabase.instance.client.auth.currentSession?.accessToken;
+    return Scaffold(
+      appBar: AppBar(title: const Text('Reset Password')),
+      body: Center(
+        child: Padding(
+          padding: const EdgeInsets.all(24),
+          child: SupaResetPassword(
+            accessToken: accessToken,
+            onSuccess: (_) => _navigateHome(context),
+            onError: (error) => _showError(context, error),
+          ),
+        ),
+      ),
+    );
+  }
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -25,6 +25,8 @@ import 'package:opennutritracker/features/settings/settings_screen.dart';
 import 'package:opennutritracker/features/create_meal/create_meal_screen.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 import 'package:opennutritracker/features/recipe/recipe_page.dart';
+import 'package:opennutritracker/features/auth/login_screen.dart';
+import 'package:opennutritracker/features/auth/reset_password_screen.dart';
 import 'package:provider/provider.dart';
 import 'package:sentry_flutter/sentry_flutter.dart';
 
@@ -114,6 +116,9 @@ class OpenNutriTrackerApp extends StatelessWidget {
         NavigationOptions.createMealRoute: (context) =>
             const MealCreationScreen(),
         NavigationOptions.recipeRoute: (context) => const RecipePage(),
+        NavigationOptions.loginRoute: (context) => const LoginScreen(),
+        NavigationOptions.resetPasswordRoute: (context) =>
+            const ResetPasswordScreen(),
       },
     );
   }

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -326,6 +326,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "4.0.1"
+  email_validator:
+    dependency: transitive
+    description:
+      name: email_validator
+      sha256: e9a90f27ab2b915a27d7f9c2a7ddda5dd752d6942616ee83529b686fc086221b
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.17"
   envied:
     dependency: "direct main"
     description:
@@ -586,6 +594,14 @@ packages:
     description: flutter
     source: sdk
     version: "0.0.0"
+  font_awesome_flutter:
+    dependency: transitive
+    description:
+      name: font_awesome_flutter
+      sha256: d3a89184101baec7f4600d58840a764d2ef760fe1c5a20ef9e6b0e9b24a07a3a
+      url: "https://pub.dev"
+    source: hosted
+    version: "10.8.0"
   frontend_server_client:
     dependency: transitive
     description:
@@ -618,6 +634,54 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.3"
+  google_identity_services_web:
+    dependency: transitive
+    description:
+      name: google_identity_services_web
+      sha256: "5d187c46dc59e02646e10fe82665fc3884a9b71bc1c90c2b8b749316d33ee454"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.3.3+1"
+  google_sign_in:
+    dependency: transitive
+    description:
+      name: google_sign_in
+      sha256: d0a2c3bcb06e607bb11e4daca48bd4b6120f0bbc4015ccebbe757d24ea60ed2a
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.3.0"
+  google_sign_in_android:
+    dependency: transitive
+    description:
+      name: google_sign_in_android
+      sha256: d5e23c56a4b84b6427552f1cf3f98f716db3b1d1a647f16b96dbb5b93afa2805
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.2.1"
+  google_sign_in_ios:
+    dependency: transitive
+    description:
+      name: google_sign_in_ios
+      sha256: "102005f498ce18442e7158f6791033bbc15ad2dcc0afa4cf4752e2722a516c96"
+      url: "https://pub.dev"
+    source: hosted
+    version: "5.9.0"
+  google_sign_in_platform_interface:
+    dependency: transitive
+    description:
+      name: google_sign_in_platform_interface
+      sha256: "5f6f79cf139c197261adb6ac024577518ae48fdff8e53205c5373b5f6430a8aa"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.5.0"
+  google_sign_in_web:
+    dependency: transitive
+    description:
+      name: google_sign_in_web
+      sha256: "460547beb4962b7623ac0fb8122d6b8268c951cf0b646dd150d60498430e4ded"
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.12.4+4"
   gotrue:
     dependency: transitive
     description:
@@ -1274,6 +1338,30 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.0"
+  sign_in_with_apple:
+    dependency: transitive
+    description:
+      name: sign_in_with_apple
+      sha256: e84a62e17b7e463abf0a64ce826c2cd1f0b72dff07b7b275e32d5302d76fb4c5
+      url: "https://pub.dev"
+    source: hosted
+    version: "6.1.4"
+  sign_in_with_apple_platform_interface:
+    dependency: transitive
+    description:
+      name: sign_in_with_apple_platform_interface
+      sha256: c2ef2ce6273fce0c61acd7e9ff5be7181e33d7aa2b66508b39418b786cca2119
+      url: "https://pub.dev"
+    source: hosted
+    version: "1.1.0"
+  sign_in_with_apple_web:
+    dependency: transitive
+    description:
+      name: sign_in_with_apple_web
+      sha256: "2f7c38368f49e3f2043bca4b46a4a61aaae568c140a79aa0675dc59ad0ca49bc"
+      url: "https://pub.dev"
+    source: hosted
+    version: "2.1.1"
   simple_gesture_detector:
     dependency: transitive
     description:
@@ -1423,6 +1511,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.6.3"
+  supabase_auth_ui:
+    dependency: "direct main"
+    description:
+      name: supabase_auth_ui
+      sha256: c1d9c5018f37701af94887fb5d15fa7eed284c58e4e06015644218a49140ec47
+      url: "https://pub.dev"
+    source: hosted
+    version: "0.5.5"
   supabase_flutter:
     dependency: "direct main"
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -75,6 +75,7 @@ dependencies:
   sentry_flutter: ^8.11.2
 
   supabase_flutter: ^2.8.2
+  supabase_auth_ui: ^0.5.5
 
 dev_dependencies:
   flutter_test:


### PR DESCRIPTION
## Summary
- add login and reset password screens using Supabase Auth UI
- add new routes for auth screens
- wire routes into main app
- include `supabase_auth_ui` package

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_685ed94de320832195bfe782d149f93e