### PR TITLE
Fix analyze warnings

### DIFF
--- a/lib/features/auth/reset_password_screen.dart
+++ b/lib/features/auth/reset_password_screen.dart
@@ -48,6 +48,7 @@ class _ResetPasswordScreenState extends State<ResetPasswordScreen> {
           ],
         ),
       );
+      if (!mounted) return;
       Navigator.of(context).pushNamedAndRemoveUntil(
         NavigationOptions.mainRoute,
         (_) => false,

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -15,7 +15,7 @@ packages:
     source: sdk
     version: "0.3.3"
   analyzer:
-    dependency: transitive
+    dependency: "direct dev"
     description:
       name: analyzer
       sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
@@ -31,7 +31,7 @@ packages:
     source: hosted
     version: "0.3.4"
   app_links:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: app_links
       sha256: "85ed8fc1d25a76475914fff28cc994653bd900bc2c26e4b57a49e097febb54ba"
@@ -351,7 +351,7 @@ packages:
     source: hosted
     version: "4.0.1"
   email_validator:
-    dependency: transitive
+    dependency: "direct main"
     description:
       name: email_validator
       sha256: e9a90f27ab2b915a27d7f9c2a7ddda5dd752d6942616ee83529b686fc086221b

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -60,6 +60,8 @@ dependencies:
 
   flutter_bloc: ^8.1.6
   equatable: ^2.0.7
+  app_links: ^6.4.0
+  email_validator: ^2.1.17
 
   percent_indicator: ^4.2.4
   horizontal_picker: ^1.2.0
@@ -91,6 +93,7 @@ dev_dependencies:
   hive_generator: ^2.0.1
   envied_generator: ^1.0.0
   mockito: ^5.4.5
+  analyzer: ^6.11.0
 
 flutter:
 


### PR DESCRIPTION
## Summary
- add missing direct dependencies
- check widget mounted after async gap
- pin analyzer to compatible version

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6862ff2ab6588321b6af9a4e0c09c4cf