### PR TITLE
Associate tracked days with logged in user

### DIFF
--- a/lib/features/sync/supabase_client.dart
+++ b/lib/features/sync/supabase_client.dart
@@ -13,7 +13,13 @@ class SupabaseTrackedDayService {
   /// Logs any exception that occurs during the operation.
   Future<void> upsertTrackedDay(Map<String, dynamic> json) async {
     try {
-      await _client.from('tracked_days').upsert(json, onConflict: 'day');
+      final uid = _client.auth.currentUser?.id;
+      if (uid != null) {
+        json['user_id'] = uid;
+      }
+      await _client
+          .from('tracked_days')
+          .upsert(json, onConflict: 'user_id, day');
     } catch (e, stackTrace) {
       _log.severe('Failed to upsert tracked day: $e', e, stackTrace);
     }
@@ -25,7 +31,15 @@ class SupabaseTrackedDayService {
   Future<void> upsertTrackedDays(List<Map<String, dynamic>> days) async {
     if (days.isEmpty) return;
     try {
-      await _client.from('tracked_days').upsert(days, onConflict: 'day');
+      final uid = _client.auth.currentUser?.id;
+      if (uid != null) {
+        for (final day in days) {
+          day['user_id'] = uid;
+        }
+      }
+      await _client
+          .from('tracked_days')
+          .upsert(days, onConflict: 'user_id, day');
     } catch (e, stackTrace) {
       _log.severe('Failed to upsert tracked days: $e', e, stackTrace);
     }

--- a/test/unit_test/supabase_client_test.dart
+++ b/test/unit_test/supabase_client_test.dart
@@ -1,3 +1,5 @@
+import 'dart:convert';
+
 import 'package:flutter_test/flutter_test.dart';
 import 'package:mock_supabase_http_client/mock_supabase_http_client.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -8,7 +10,9 @@ void main() {
   late final MockSupabaseHttpClient mockHttpClient;
   late final SupabaseTrackedDayService trackedDayService;
 
-  setUpAll(() {
+  const userId = 'user123';
+
+  setUpAll(() async {
     mockHttpClient = MockSupabaseHttpClient();
 
     // Inject mockHttpClient properly
@@ -17,6 +21,24 @@ void main() {
       'fakeAnonKey',
       httpClient: mockHttpClient,
     );
+
+    final user = User(
+      id: userId,
+      appMetadata: const {},
+      userMetadata: const {},
+      aud: 'authenticated',
+      createdAt: DateTime.now().toIso8601String(),
+    );
+
+    final session = Session(
+      accessToken: 'token',
+      tokenType: 'bearer',
+      user: user,
+      refreshToken: 'refresh',
+      expiresIn: 3600,
+    );
+
+    await mockSupabase.auth.recoverSession(jsonEncode(session.toJson()));
 
     trackedDayService = SupabaseTrackedDayService(client: mockSupabase);
   });
@@ -49,6 +71,7 @@ void main() {
       'carbs': 300,
       'proteins': 100,
       'fats': 70,
+      'user_id': userId,
     });
   });
 
@@ -84,6 +107,7 @@ void main() {
             'carbs': 250,
             'proteins': 90,
             'fats': 60,
+            'user_id': userId,
           },
           {
             'day': today.toIso8601String(),
@@ -91,6 +115,7 @@ void main() {
             'carbs': 320,
             'proteins': 110,
             'fats': 80,
+            'user_id': userId,
           },
         ]));
   });


### PR DESCRIPTION
## Summary
- add user_id handling in `SupabaseTrackedDayService`
- expect user id in upsert tests
- ensure isolate sync tests handle user field

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68642fb6a30c8321aed607a71092046b