### PR TITLE
Add Supabase backup option

### DIFF
--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -68,6 +68,7 @@ import 'package:opennutritracker/features/scanner/domain/usecase/search_product_
 import 'package:opennutritracker/features/scanner/presentation/scanner_bloc.dart';
 import 'package:opennutritracker/features/settings/domain/usecase/export_data_usecase.dart';
 import 'package:opennutritracker/features/settings/domain/usecase/import_data_usecase.dart';
+import 'package:opennutritracker/features/settings/domain/usecase/export_data_supabase_usecase.dart';
 import 'package:opennutritracker/features/settings/presentation/bloc/export_import_bloc.dart';
 import 'package:opennutritracker/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -115,7 +116,8 @@ Future<void> initLocator() async {
       () => ProfileBloc(locator(), locator(), locator(), locator(), locator()));
   locator.registerLazySingleton(() =>
       SettingsBloc(locator(), locator(), locator(), locator(), locator()));
-  locator.registerFactory(() => ExportImportBloc(locator(), locator()));
+  locator.registerFactory(() =>
+      ExportImportBloc(locator(), locator(), locator()));
   locator
       .registerLazySingleton<CreateMealBloc>(() => CreateMealBloc(locator()));
 
@@ -183,6 +185,8 @@ Future<void> initLocator() async {
       () => ExportDataUsecase(locator(), locator(), locator()));
   locator.registerLazySingleton(
       () => ImportDataUsecase(locator(), locator(), locator()));
+  locator.registerLazySingleton(
+      () => ExportDataSupabaseUsecase(locator(), locator(), locator(), locator()));
   locator.registerLazySingleton<AddWeightUsecase>(
       () => AddWeightUsecase(locator()));
   locator.registerLazySingleton<GetWeightUsecase>(() => GetWeightUsecase());

--- a/lib/features/settings/domain/usecase/export_data_supabase_usecase.dart
+++ b/lib/features/settings/domain/usecase/export_data_supabase_usecase.dart
@@ -1,0 +1,72 @@
+import 'dart:convert';
+import 'dart:typed_data';
+
+import 'package:archive/archive_io.dart';
+import 'package:opennutritracker/core/data/repository/intake_repository.dart';
+import 'package:opennutritracker/core/data/repository/tracked_day_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:logging/logging.dart';
+
+/// Exports user data to a zip file and uploads it to Supabase storage.
+class ExportDataSupabaseUsecase {
+  final UserActivityRepository _userActivityRepository;
+  final IntakeRepository _intakeRepository;
+  final TrackedDayRepository _trackedDayRepository;
+  final SupabaseClient _client;
+  final _log = Logger('ExportServiceZipSupabaseUsecase');
+
+  ExportDataSupabaseUsecase(this._userActivityRepository,
+      this._intakeRepository, this._trackedDayRepository, this._client);
+
+  /// Creates a zipped backup and uploads it to Supabase storage.
+  Future<bool> exportData(
+    String exportZipFileName,
+    String userActivityJsonFileName,
+    String userIntakeJsonFileName,
+    String trackedDayJsonFileName,
+  ) async {
+    // Export user activity data to Json File Bytes
+    final fullUserActivity =
+        await _userActivityRepository.getAllUserActivityDBO();
+    final fullUserActivityJson = jsonEncode(
+        fullUserActivity.map((activity) => activity.toJson()).toList());
+    final userActivityJsonBytes = utf8.encode(fullUserActivityJson);
+
+    // Export intake data to Json File Bytes
+    final fullIntake = await _intakeRepository.getAllIntakesDBO();
+    final fullIntakeJson =
+        jsonEncode(fullIntake.map((intake) => intake.toJson()).toList());
+    final intakeJsonBytes = utf8.encode(fullIntakeJson);
+
+    // Export tracked day data to Json File Bytes
+    final fullTrackedDay = await _trackedDayRepository.getAllTrackedDaysDBO();
+    final fullTrackedDayJson = jsonEncode(
+        fullTrackedDay.map((trackedDay) => trackedDay.toJson()).toList());
+    final trackedDayJsonBytes = utf8.encode(fullTrackedDayJson);
+
+    // Create a zip file with the exported data
+    final archive = Archive()
+      ..addFile(ArchiveFile(userActivityJsonFileName,
+          userActivityJsonBytes.length, userActivityJsonBytes))
+      ..addFile(ArchiveFile(
+          userIntakeJsonFileName, intakeJsonBytes.length, intakeJsonBytes))
+      ..addFile(ArchiveFile(trackedDayJsonFileName, trackedDayJsonBytes.length,
+          trackedDayJsonBytes));
+
+    final zipBytes = ZipEncoder().encode(archive);
+
+    final userId = _client.auth.currentUser?.id ?? 'unknown';
+    final filePath = '$userId/$exportZipFileName';
+    try {
+      await _client.storage.from('exports').uploadBinary(
+          filePath, Uint8List.fromList(zipBytes),
+          fileOptions:
+              const FileOptions(contentType: 'application/zip', upsert: true));
+      return true;
+    } catch (e, stack) {
+      _log.severe('Upload FAILED for “$filePath”.', e, stack);
+      return false;
+    }
+  }
+}

--- a/lib/features/settings/presentation/bloc/export_import_bloc.dart
+++ b/lib/features/settings/presentation/bloc/export_import_bloc.dart
@@ -2,6 +2,7 @@ import 'package:equatable/equatable.dart';
 import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:opennutritracker/features/settings/domain/usecase/export_data_usecase.dart';
 import 'package:opennutritracker/features/settings/domain/usecase/import_data_usecase.dart';
+import 'package:opennutritracker/features/settings/domain/usecase/export_data_supabase_usecase.dart';
 
 part 'export_import_event.dart';
 
@@ -15,8 +16,10 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
 
   final ExportDataUsecase _exportDataUsecase;
   final ImportDataUsecase _importDataUsecase;
+  final ExportDataSupabaseUsecase _exportDataSupabaseUsecase;
 
-  ExportImportBloc(this._exportDataUsecase, this._importDataUsecase)
+  ExportImportBloc(this._exportDataUsecase, this._importDataUsecase,
+      this._exportDataSupabaseUsecase)
       : super(ExportImportInitial()) {
     on<ExportDataEvent>((event, emit) async {
       try {
@@ -33,6 +36,27 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
           emit(ExportImportSuccess());
         } else {
           emit(ExportImportInitial());
+        }
+      } catch (e) {
+        emit(ExportImportError());
+      }
+    });
+
+    on<ExportDataSupabaseEvent>((event, emit) async {
+      try {
+        emit(ExportImportLoadingState());
+
+        final result = await _exportDataSupabaseUsecase.exportData(
+          exportZipFileName,
+          userActivityJsonFileName,
+          userIntakeJsonFileName,
+          trackedDayJsonFileName,
+        );
+
+        if (result) {
+          emit(ExportImportSuccess());
+        } else {
+          emit(ExportImportError());
         }
       } catch (e) {
         emit(ExportImportError());

--- a/lib/features/settings/presentation/bloc/export_import_event.dart
+++ b/lib/features/settings/presentation/bloc/export_import_event.dart
@@ -13,3 +13,8 @@ class ImportDataEvent extends ExportImportEvent {
   @override
   List<Object?> get props => [];
 }
+
+class ExportDataSupabaseEvent extends ExportImportEvent {
+  @override
+  List<Object?> get props => [];
+}

--- a/lib/features/settings/presentation/widgets/export_supabase_dialog.dart
+++ b/lib/features/settings/presentation/widgets/export_supabase_dialog.dart
@@ -1,0 +1,93 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
+import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/features/settings/presentation/bloc/export_import_bloc.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+class ExportSupabaseDialog extends StatelessWidget {
+  final exportImportBloc = locator<ExportImportBloc>();
+
+  final _homeBloc = locator<HomeBloc>();
+  final _diaryBloc = locator<DiaryBloc>();
+  final _calendarDayBloc = locator<CalendarDayBloc>();
+
+  ExportSupabaseDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(S.of(context).exportSupabaseLabel,
+          overflow: TextOverflow.ellipsis, maxLines: 2),
+      content: Wrap(children: [
+        Column(
+          children: [
+            BlocBuilder<ExportImportBloc, ExportImportState>(
+                bloc: exportImportBloc,
+                builder: (context, state) {
+                  if (state is ExportImportInitial) {
+                    return Text(
+                      S.of(context).exportSupabaseDescription,
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 15,
+                    );
+                  } else if (state is ExportImportLoadingState) {
+                    return const LinearProgressIndicator();
+                  } else if (state is ExportImportSuccess) {
+                    refreshScreens();
+                    return Row(
+                      children: [
+                        Icon(Icons.check_circle,
+                            color: Theme.of(context).colorScheme.primary),
+                        const SizedBox(width: 8),
+                        Text(
+                          S.of(context).exportImportSuccessLabel,
+                        ),
+                      ],
+                    );
+                  } else if (state is ExportImportError) {
+                    return Row(
+                      crossAxisAlignment: CrossAxisAlignment
+                          .start, // Important to properly align multi-line text with the icon
+                      children: [
+                        Icon(
+                          Icons.error,
+                          color: Theme.of(context).colorScheme.error,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            S.of(context).exportImportErrorLabel,
+                            softWrap: true, // Allows line wrapping
+                            overflow:
+                                TextOverflow.visible, // Prevents truncation
+                          ),
+                        ),
+                      ],
+                    );
+                  }
+
+                  return const SizedBox.shrink();
+                }),
+          ],
+        ),
+      ]),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () {
+            exportImportBloc.add(ExportDataSupabaseEvent());
+          },
+          child: Text(S.of(context).exportAction),
+        ),
+      ],
+    );
+  }
+
+  void refreshScreens() {
+    _homeBloc.add(const LoadItemsEvent());
+    _diaryBloc.add(const LoadDiaryYearEvent());
+    _calendarDayBloc.add(RefreshCalendarDayEvent());
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -13,6 +13,7 @@ import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart'
 import 'package:opennutritracker/features/profile/presentation/bloc/profile_bloc.dart';
 import 'package:opennutritracker/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:opennutritracker/features/settings/presentation/widgets/export_import_dialog.dart';
+import 'package:opennutritracker/features/settings/presentation/widgets/export_supabase_dialog.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
@@ -81,6 +82,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   leading: const Icon(Icons.import_export),
                   title: Text(S.of(context).exportImportLabel),
                   onTap: () => _showExportImportDialog(context),
+                ),
+                ListTile(
+                  leading: const Icon(Icons.cloud_upload_outlined),
+                  title: Text(S.of(context).exportSupabaseLabel),
+                  onTap: () => _showExportSupabaseDialog(context),
                 ),
                 ListTile(
                   leading: const Icon(Icons.description_outlined),
@@ -185,6 +191,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
     showDialog(
       context: context,
       builder: (context) => ExportImportDialog(),
+    );
+  }
+
+  void _showExportSupabaseDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => ExportSupabaseDialog(),
     );
   }
 

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -156,6 +156,10 @@ class MessageLookup extends MessageLookupByLibrary {
             "Daten Exportieren / Importieren"),
         "exportImportSuccessLabel":
             MessageLookupByLibrary.simpleMessage("Export / Import erfolgreich"),
+        "exportSupabaseDescription": MessageLookupByLibrary.simpleMessage(
+            "Sichere deine Daten als Zip-Datei im Supabase-Speicher."),
+        "exportSupabaseLabel":
+            MessageLookupByLibrary.simpleMessage("Zu Supabase exportieren"),
         "fatLabel": MessageLookupByLibrary.simpleMessage("Fett"),
         "fiberLabel": MessageLookupByLibrary.simpleMessage("Ballaststoffe"),
         "flOzUnit": MessageLookupByLibrary.simpleMessage("fl.oz"),

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -158,6 +158,10 @@ class MessageLookup extends MessageLookupByLibrary {
             MessageLookupByLibrary.simpleMessage("Export / Import data"),
         "exportImportSuccessLabel":
             MessageLookupByLibrary.simpleMessage("Export / Import successful"),
+        "exportSupabaseDescription": MessageLookupByLibrary.simpleMessage(
+            "Backup your data to Supabase storage as a zip file."),
+        "exportSupabaseLabel":
+            MessageLookupByLibrary.simpleMessage("Export to Supabase"),
         "fatLabel": MessageLookupByLibrary.simpleMessage("fat"),
         "fiberLabel": MessageLookupByLibrary.simpleMessage("fiber"),
         "flOzUnit": MessageLookupByLibrary.simpleMessage("fl.oz"),

--- a/lib/generated/intl/messages_fr.dart
+++ b/lib/generated/intl/messages_fr.dart
@@ -163,6 +163,10 @@ class MessageLookup extends MessageLookupByLibrary {
             "Exporter / Importer des données"),
         "exportImportSuccessLabel": MessageLookupByLibrary.simpleMessage(
             "Exportation / Importation réussie"),
+        "exportSupabaseDescription": MessageLookupByLibrary.simpleMessage(
+            "Sauvegardez vos données dans le stockage Supabase sous forme de fichier zip."),
+        "exportSupabaseLabel":
+            MessageLookupByLibrary.simpleMessage("Exporter vers Supabase"),
         "fatLabel": MessageLookupByLibrary.simpleMessage("lipides"),
         "fiberLabel": MessageLookupByLibrary.simpleMessage("fibres"),
         "flOzUnit": MessageLookupByLibrary.simpleMessage("fl.oz"),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -152,6 +152,10 @@ class MessageLookup extends MessageLookupByLibrary {
             "Verileri Dışa Aktar / İçe Aktar"),
         "exportImportSuccessLabel": MessageLookupByLibrary.simpleMessage(
             "Dışa Aktarma / İçe Aktarma başarılı"),
+        "exportSupabaseDescription": MessageLookupByLibrary.simpleMessage(
+            "Verilerinizi zip dosyası olarak Supabase depolamasına yedekleyin."),
+        "exportSupabaseLabel":
+            MessageLookupByLibrary.simpleMessage("Supabase\'e Aktar"),
         "fatLabel": MessageLookupByLibrary.simpleMessage("yağ"),
         "fiberLabel": MessageLookupByLibrary.simpleMessage("lif"),
         "flOzUnit": MessageLookupByLibrary.simpleMessage("fl.oz"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1212,6 +1212,26 @@ class S {
     );
   }
 
+  /// `Export to Supabase`
+  String get exportSupabaseLabel {
+    return Intl.message(
+      'Export to Supabase',
+      name: 'exportSupabaseLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Backup your data to Supabase storage as a zip file.`
+  String get exportSupabaseDescription {
+    return Intl.message(
+      'Backup your data to Supabase storage as a zip file.',
+      name: 'exportSupabaseDescription',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Add new Item:`
   String get addItemLabel {
     return Intl.message(

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -108,6 +108,8 @@
   "exportImportErrorLabel": "Fehler beim Export/Import",
   "exportAction": "Exportieren",
   "importAction": "Importieren",
+  "exportSupabaseLabel": "Zu Supabase exportieren",
+  "exportSupabaseDescription": "Sichere deine Daten als Zip-Datei im Supabase-Speicher.",
   "addItemLabel": "Neuen Eintrag hinzufügen:",
   "activityLabel": "Aktivität",
   "activityExample": "z. B. Laufen, Radfahren, Yoga ...",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -118,6 +118,8 @@
   "exportImportErrorLabel": "Export / Import error",
   "exportAction": "Export",
   "importAction": "Import",
+  "exportSupabaseLabel": "Export to Supabase",
+  "exportSupabaseDescription": "Backup your data to Supabase storage as a zip file.",
   "addItemLabel": "Add new Item:",
   "activityLabel": "Activity",
   "activityExample": "e.g. running, biking, yoga ...",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -118,6 +118,8 @@
   "exportImportErrorLabel": "Erreur d'exportation / d'importation",
   "exportAction": "Exporter",
   "importAction": "Importer",
+  "exportSupabaseLabel": "Exporter vers Supabase",
+  "exportSupabaseDescription": "Sauvegardez vos données dans le stockage Supabase sous forme de fichier zip.",
   "addItemLabel": "Ajouter un nouvel élément :",
   "activityLabel": "Activité",
   "activityExample": "ex : course, vélo, yoga...",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -113,6 +113,8 @@
   "exportImportErrorLabel": "Dışa Aktarma / İçe Aktarma hatası",
   "exportAction": "Dışa Aktar",
   "importAction": "İçe Aktar",
+  "exportSupabaseLabel": "Supabase'e Aktar",
+  "exportSupabaseDescription": "Verilerinizi zip dosyası olarak Supabase depolamasına yedekleyin.",
   "addItemLabel": "Yeni Öğe Ekle:",
   "activityLabel": "Aktivite",
   "activityExample": "ör. koşu, bisiklet, yoga ...",

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -638,10 +638,10 @@ packages:
     dependency: transitive
     description:
       name: functions_client
-      sha256: a49876ebae32a50eb62483c5c5ac80ed0d8da34f98ccc23986b03a8d28cee07c
+      sha256: "91bd57c5ee843957bfee68fdcd7a2e8b3c1081d448e945d33ff695fb9c2a686c"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.3"
   get_it:
     dependency: "direct main"
     description:
@@ -710,10 +710,10 @@ packages:
     dependency: transitive
     description:
       name: gotrue
-      sha256: d6362dff9a54f8c1c372bb137c858b4024c16407324d34e6473e59623c9b9f50
+      sha256: "941694654ab659990547798569771d8d092f2ade84a72e75bb9bbca249f3d3b1"
       url: "https://pub.dev"
     source: hosted
-    version: "2.11.1"
+    version: "2.13.0"
   graphs:
     dependency: transitive
     description:
@@ -1214,10 +1214,10 @@ packages:
     dependency: transitive
     description:
       name: postgrest
-      sha256: b74dc0f57b5dca5ce9f57a54b08110bf41d6fc8a0483c0fec10c79e9aa0fb2bb
+      sha256: "10b81a23b1c829ccadf68c626b4d66666453a1474d24c563f313f5ca7851d575"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   provider:
     dependency: "direct main"
     description:
@@ -1246,10 +1246,10 @@ packages:
     dependency: transitive
     description:
       name: realtime_client
-      sha256: e3089dac2121917cc0c72d42ab056fea0abbaf3c2229048fc50e64bafc731adf
+      sha256: b6a825a4c80f2281ebfbbcf436a8979ae9993d4a30dbcf011b7d2b82ddde9edd
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.2"
+    version: "2.5.1"
   recase:
     dependency: transitive
     description:
@@ -1515,10 +1515,10 @@ packages:
     dependency: transitive
     description:
       name: storage_client
-      sha256: "9f9ed283943313b23a1b27139bb18986e9b152a6d34530232c702c468d98e91a"
+      sha256: "09bac4d75eea58e8113ca928e6655a09cc8059e6d1b472ee801f01fde815bcfc"
       url: "https://pub.dev"
     source: hosted
-    version: "2.3.1"
+    version: "2.4.0"
   stream_channel:
     dependency: transitive
     description:
@@ -1547,10 +1547,10 @@ packages:
     dependency: transitive
     description:
       name: supabase
-      sha256: c3ebddba69ddcf16d8b78e8c44c4538b0193d1cf944fde3b72eb5b279892a370
+      sha256: "56c3493114caac8ef0dc3cac5fa24a9edefeb8c22d45794814c0fe3d2feb1a98"
       url: "https://pub.dev"
     source: hosted
-    version: "2.6.3"
+    version: "2.8.0"
   supabase_auth_ui:
     dependency: "direct main"
     description:
@@ -1563,10 +1563,10 @@ packages:
     dependency: "direct main"
     description:
       name: supabase_flutter
-      sha256: "3b5b5b492e342f63f301605d0c66f6528add285b5744f53c9fd9abd5ffdbce5b"
+      sha256: "66b8d0a7a31f45955b11ad7b65347abc61b31e10f8bdfa4428501b81f5b30fa5"
       url: "https://pub.dev"
     source: hosted
-    version: "2.8.4"
+    version: "2.9.1"
   syncfusion_flutter_charts:
     dependency: "direct main"
     description:
@@ -1835,10 +1835,10 @@ packages:
     dependency: transitive
     description:
       name: yet_another_json_isolate
-      sha256: "56155e9e0002cc51ea7112857bbcdc714d4c35e176d43e4d3ee233009ff410c9"
+      sha256: fe45897501fa156ccefbfb9359c9462ce5dec092f05e8a56109db30be864f01e
       url: "https://pub.dev"
     source: hosted
-    version: "2.0.3"
+    version: "2.1.0"
 sdks:
   dart: ">=3.7.0 <4.0.0"
   flutter: ">=3.27.0"

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -79,7 +79,7 @@ dependencies:
 
   sentry_flutter: ^8.11.2
 
-  supabase_flutter: ^2.8.2
+  supabase_flutter: ^2.9.1
   syncfusion_flutter_charts: ^29.1.38
 
   supabase_auth_ui: ^0.5.5


### PR DESCRIPTION
## Summary
- add export to Supabase storage usecase
- handle new export event in bloc
- dialog and settings option for Supabase export
- translate new strings

## Testing
- `flutter pub get`
- `flutter pub run intl_utils:generate`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_6866e741dc548321a04fcb15f8a7d535