### PR TITLE
Add user weight export/import

### DIFF
--- a/lib/core/data/data_source/user_weight_data_source.dart
+++ b/lib/core/data/data_source/user_weight_data_source.dart
@@ -34,4 +34,15 @@ class UserWeightDataSource {
     }
     return null;
   }
+
+  Future<List<UserWeightDbo>> getAllUserWeights() async {
+    return _userWeightBox.values.toList();
+  }
+
+  Future<void> addAllUserWeights(List<UserWeightDbo> userWeightDbos) async {
+    final Map<String, UserWeightDbo> mapped = {
+      for (var dbo in userWeightDbos) _normaliseDateToKey(dbo.date): dbo
+    };
+    await _userWeightBox.putAll(mapped);
+  }
 }

--- a/lib/core/data/repository/user_weight_repository.dart
+++ b/lib/core/data/repository/user_weight_repository.dart
@@ -36,4 +36,12 @@ class UserWeightRepository {
     }
     return UserWeightEntity.fromUserWeightDbo(lastUserWeight);
   }
+
+  Future<List<UserWeightDbo>> getAllUserWeightDBOs() async {
+    return await _userWeightDataSource.getAllUserWeights();
+  }
+
+  Future<void> addAllUserWeightDBOs(List<UserWeightDbo> userWeights) async {
+    await _userWeightDataSource.addAllUserWeights(userWeights);
+  }
 }

--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -182,11 +182,12 @@ Future<void> initLocator() async {
       () => GetKcalGoalUsecase(locator(), locator(), locator()));
   locator.registerLazySingleton(() => GetMacroGoalUsecase(locator()));
   locator.registerLazySingleton(
-      () => ExportDataUsecase(locator(), locator(), locator()));
+      () => ExportDataUsecase(locator(), locator(), locator(), locator()));
   locator.registerLazySingleton(
-      () => ImportDataUsecase(locator(), locator(), locator()));
+      () => ImportDataUsecase(locator(), locator(), locator(), locator()));
   locator.registerLazySingleton(
-      () => ExportDataSupabaseUsecase(locator(), locator(), locator(), locator()));
+      () => ExportDataSupabaseUsecase(
+          locator(), locator(), locator(), locator(), locator()));
   locator.registerLazySingleton<AddWeightUsecase>(
       () => AddWeightUsecase(locator()));
   locator.registerLazySingleton<GetWeightUsecase>(() => GetWeightUsecase());

--- a/lib/features/auth/auth_safe_sign_out.dart
+++ b/lib/features/auth/auth_safe_sign_out.dart
@@ -32,6 +32,7 @@ Future<void> safeSignOut(BuildContext context) async {
         ExportImportBloc.userActivityJsonFileName,
         ExportImportBloc.userIntakeJsonFileName,
         ExportImportBloc.trackedDayJsonFileName,
+        ExportImportBloc.userWeightJsonFileName,
       );
       _log.log(ok ? Level.FINE : Level.WARNING,
           ok ? 'Export réussi' : 'Export échoué – on continue quand même');

--- a/lib/features/settings/domain/usecase/export_data_usecase.dart
+++ b/lib/features/settings/domain/usecase/export_data_usecase.dart
@@ -6,14 +6,16 @@ import 'package:file_picker/file_picker.dart';
 import 'package:opennutritracker/core/data/repository/intake_repository.dart';
 import 'package:opennutritracker/core/data/repository/tracked_day_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_weight_repository.dart';
 
 class ExportDataUsecase {
   final UserActivityRepository _userActivityRepository;
   final IntakeRepository _intakeRepository;
   final TrackedDayRepository _trackedDayRepository;
+  final UserWeightRepository _userWeightRepository;
 
   ExportDataUsecase(this._userActivityRepository, this._intakeRepository,
-      this._trackedDayRepository);
+      this._trackedDayRepository, this._userWeightRepository);
 
   /// Exports user activity, intake, and tracked day data to a zip of json
   /// files at a user specified location.
@@ -21,7 +23,8 @@ class ExportDataUsecase {
       String exportZipFileName,
       String userActivityJsonFileName,
       String userIntakeJsonFileName,
-      String trackedDayJsonFileName) async {
+      String trackedDayJsonFileName,
+      String userWeightJsonFileName) async {
     // Export user activity data to Json File Bytes
     final fullUserActivity =
         await _userActivityRepository.getAllUserActivityDBO();
@@ -41,6 +44,12 @@ class ExportDataUsecase {
         fullTrackedDay.map((trackedDay) => trackedDay.toJson()).toList());
     final trackedDayJsonBytes = utf8.encode(fullTrackedDayJson);
 
+    // Export user weight data to Json File Bytes
+    final fullUserWeight = await _userWeightRepository.getAllUserWeightDBOs();
+    final fullUserWeightJson =
+        jsonEncode(fullUserWeight.map((w) => w.toJson()).toList());
+    final userWeightJsonBytes = utf8.encode(fullUserWeightJson);
+
     // Create a zip file with the exported data
     final archive = Archive();
     archive.addFile(
@@ -54,6 +63,10 @@ class ExportDataUsecase {
     archive.addFile(
       ArchiveFile(trackedDayJsonFileName, trackedDayJsonBytes.length,
           trackedDayJsonBytes),
+    );
+    archive.addFile(
+      ArchiveFile(userWeightJsonFileName, userWeightJsonBytes.length,
+          userWeightJsonBytes),
     );
 
     // Save the zip file to the user specified location

--- a/lib/features/settings/presentation/bloc/export_import_bloc.dart
+++ b/lib/features/settings/presentation/bloc/export_import_bloc.dart
@@ -13,6 +13,7 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
   static const userActivityJsonFileName = 'user_activity.json';
   static const userIntakeJsonFileName = 'user_intake.json';
   static const trackedDayJsonFileName = 'user_tracked_day.json';
+  static const userWeightJsonFileName = 'user_weight.json';
 
   final ExportDataUsecase _exportDataUsecase;
   final ImportDataUsecase _importDataUsecase;
@@ -30,6 +31,7 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
           userActivityJsonFileName,
           userIntakeJsonFileName,
           trackedDayJsonFileName,
+          userWeightJsonFileName,
         );
 
         if (result) {
@@ -51,6 +53,7 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
           userActivityJsonFileName,
           userIntakeJsonFileName,
           trackedDayJsonFileName,
+          userWeightJsonFileName,
         );
 
         if (result) {
@@ -70,7 +73,8 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
         final result = await _importDataUsecase.importData(
             userActivityJsonFileName,
             userIntakeJsonFileName,
-            trackedDayJsonFileName);
+            trackedDayJsonFileName,
+            userWeightJsonFileName);
         if (result) {
           emit(ExportImportSuccess());
         } else {


### PR DESCRIPTION
## Summary
- add CRUD list features for user weight DBO
- support exporting user weight data to ZIP
- support importing user weight data from ZIP
- wire new repository into service locator
- update presentation bloc and sign-out helper

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_6868e52bbfa0832189c47cdce6a47e90