### PR TITLE
Refactor data sources to use HiveDBProvider

### DIFF
--- a/lib/core/data/data_source/config_data_source.dart
+++ b/lib/core/data/data_source/config_data_source.dart
@@ -1,30 +1,30 @@
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/app_theme_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/config_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class ConfigDataSource {
   static const _configKey = "ConfigKey";
 
   final _log = Logger('ConfigDataSource');
-  final Box<ConfigDBO> _configBox;
+  final HiveDBProvider _hive;
 
-  ConfigDataSource(this._configBox);
+  ConfigDataSource(this._hive);
 
-  Future<bool> configInitialized() async => _configBox.containsKey(_configKey);
+  Future<bool> configInitialized() async => _hive.configBox.containsKey(_configKey);
 
   Future<void> initializeConfig() async =>
-      _configBox.put(_configKey, ConfigDBO.empty());
+      _hive.configBox.put(_configKey, ConfigDBO.empty());
 
   Future<void> addConfig(ConfigDBO configDBO) async {
     _log.fine('Adding new config item to db');
-    _configBox.put(_configKey, configDBO);
+    _hive.configBox.put(_configKey, configDBO);
   }
 
   Future<void> setConfigDisclaimer(bool hasAcceptedDisclaimer) async {
     _log.fine(
         'Updating config hasAcceptedDisclaimer to $hasAcceptedDisclaimer');
-    final config = _configBox.get(_configKey);
+    final config = _hive.configBox.get(_configKey);
     config?.hasAcceptedDisclaimer = hasAcceptedDisclaimer;
     config?.save();
   }
@@ -33,69 +33,69 @@ class ConfigDataSource {
       bool hasAcceptedAnonymousData) async {
     _log.fine(
         'Updating config hasAcceptedAnonymousData to $hasAcceptedAnonymousData');
-    final config = _configBox.get(_configKey);
+    final config = _hive.configBox.get(_configKey);
     config?.hasAcceptedSendAnonymousData = hasAcceptedAnonymousData;
     config?.save();
   }
 
   Future<AppThemeDBO> getAppTheme() async {
-    final config = _configBox.get(_configKey);
+    final config = _hive.configBox.get(_configKey);
     return config?.selectedAppTheme ?? AppThemeDBO.defaultTheme;
   }
 
   Future<void> setConfigAppTheme(AppThemeDBO appTheme) async {
     _log.fine('Updating config appTheme to $appTheme');
-    final config = _configBox.get(_configKey);
+    final config = _hive.configBox.get(_configKey);
     config?.selectedAppTheme = appTheme;
     config?.save();
   }
 
   Future<void> setConfigUsesImperialUnits(bool usesImperialUnits) async {
     _log.fine('Updating config usesImperialUnits to $usesImperialUnits');
-    final config = _configBox.get(_configKey);
+    final config = _hive.configBox.get(_configKey);
     config?.usesImperialUnits = usesImperialUnits;
     config?.save();
   }
 
   Future<double> getKcalAdjustment() async {
-    final config = _configBox.get(_configKey);
+    final config = _hive.configBox.get(_configKey);
     return config?.userKcalAdjustment ?? 0;
   }
 
   Future<void> setConfigKcalAdjustment(double kcalAdjustment) async {
     _log.fine('Updating config kcalAdjustment to $kcalAdjustment');
-    final config = _configBox.get(_configKey);
+    final config = _hive.configBox.get(_configKey);
     config?.userKcalAdjustment = kcalAdjustment;
     config?.save();
   }
 
   Future<void> setConfigCarbGoalPct(double carbGoalPct) async {
     _log.fine('Updating config carbGoalPct to $carbGoalPct');
-    final config = _configBox.get(_configKey);
+    final config = _hive.configBox.get(_configKey);
     config?.userCarbGoalPct = carbGoalPct;
     config?.save();
   }
 
   Future<void> setConfigProteinGoalPct(double proteinGoalPct) async {
     _log.fine('Updating config proteinGoalPct to $proteinGoalPct');
-    final config = _configBox.get(_configKey);
+    final config = _hive.configBox.get(_configKey);
     config?.userProteinGoalPct = proteinGoalPct;
     config?.save();
   }
 
   Future<void> setConfigFatGoalPct(double fatGoalPct) async {
     _log.fine('Updating config fatGoalPct to $fatGoalPct');
-    final config = _configBox.get(_configKey);
+    final config = _hive.configBox.get(_configKey);
     config?.userFatGoalPct = fatGoalPct;
     config?.save();
   }
 
   Future<ConfigDBO> getConfig() async {
-    return _configBox.get(_configKey) ?? ConfigDBO.empty();
+    return _hive.configBox.get(_configKey) ?? ConfigDBO.empty();
   }
 
   Future<bool> getHasAcceptedAnonymousData() async {
-    final config = _configBox.get(_configKey);
+    final config = _hive.configBox.get(_configKey);
     return config?.hasAcceptedSendAnonymousData ?? false;
   }
 }

--- a/lib/core/data/data_source/intake_data_source.dart
+++ b/lib/core/data/data_source/intake_data_source.dart
@@ -1,30 +1,30 @@
 import 'package:collection/collection.dart';
 import 'package:flutter/material.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/intake_type_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class IntakeDataSource {
   final log = Logger('IntakeDataSource');
-  final Box<IntakeDBO> _intakeBox;
+  final HiveDBProvider _hive;
 
-  IntakeDataSource(this._intakeBox);
+  IntakeDataSource(this._hive);
 
   Future<void> addIntake(IntakeDBO intakeDBO) async {
     log.fine('Adding new intake item to db');
-    _intakeBox.add(intakeDBO);
+    _hive.intakeBox.add(intakeDBO);
   }
 
   Future<void> addAllIntakes(List<IntakeDBO> intakeDBOList) async {
     log.fine('Adding new intake items to db');
-    _intakeBox.addAll(intakeDBOList);
+    _hive.intakeBox.addAll(intakeDBOList);
   }
 
   Future<void> deleteIntakeFromId(String intakeId) async {
     log.fine('Deleting intake item from db');
-    _intakeBox.values
+    _hive.intakeBox.values
         .where((dbo) => dbo.id == intakeId)
         .toList()
         .forEach((element) {
@@ -36,7 +36,7 @@ class IntakeDataSource {
       String intakeId, Map<String, dynamic> fields) async {
     log.fine(
         'Updating intake $intakeId with fields ${fields.toString()} in db');
-    var intakeObject = _intakeBox.values.indexed
+    var intakeObject = _hive.intakeBox.values.indexed
         .where((indexedDbo) => indexedDbo.$2.id == intakeId)
         .firstOrNull;
     if (intakeObject == null) {
@@ -44,28 +44,28 @@ class IntakeDataSource {
       return null;
     }
     intakeObject.$2.amount = fields['amount'] ?? intakeObject.$2.amount;
-    _intakeBox.putAt(intakeObject.$1, intakeObject.$2);
-    return _intakeBox.getAt(intakeObject.$1);
+    _hive.intakeBox.putAt(intakeObject.$1, intakeObject.$2);
+    return _hive.intakeBox.getAt(intakeObject.$1);
   }
 
   Future<IntakeDBO?> getIntakeById(String intakeId) async {
-    return _intakeBox.values
+    return _hive.intakeBox.values
         .firstWhereOrNull((intake) => intake.id == intakeId);
   }
 
   Future<List<IntakeDBO>> getIntakeRecipe() async {
-    return _intakeBox.values
+    return _hive.intakeBox.values
         .where((intake) => intake.meal.nutriments.mealOrRecipe == MealOrRecipeDBO.recipe)
         .toList();
   }
 
   Future<List<IntakeDBO>> getAllIntakes() async {
-    return _intakeBox.values.toList();
+    return _hive.intakeBox.values.toList();
   }
 
   Future<List<IntakeDBO>> getAllIntakesByDate(
       IntakeTypeDBO intakeType, DateTime dateTime) async {
-    return _intakeBox.values
+    return _hive.intakeBox.values
         .where((intake) =>
             DateUtils.isSameDay(dateTime, intake.dateTime) &&
             intake.type == intakeType)
@@ -73,7 +73,7 @@ class IntakeDataSource {
   }
 
   Future<List<IntakeDBO>> getRecentlyAddedIntake({int number = 100}) async {
-    final intakeList = _intakeBox.values.toList();
+    final intakeList = _hive.intakeBox.values.toList();
 
     //  sort list by date (newest first) and filter unique intake
     intakeList.sort((a, b) => (-1) * a.dateTime.compareTo(b.dateTime));

--- a/lib/core/data/data_source/recipe_data_source.dart
+++ b/lib/core/data/data_source/recipe_data_source.dart
@@ -1,17 +1,17 @@
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class RecipesDataSource {
   final log = Logger('RecipesDataSource');
-  final Box<RecipesDBO> _recipesBox;
+  final HiveDBProvider _hive;
 
-  RecipesDataSource(this._recipesBox);
+  RecipesDataSource(this._hive);
 
   /// Ajouter une recette complète
   Future<void> addRecipe(RecipesDBO recipe) async {
     log.fine('Adding new recipe to db');
-    await _recipesBox.put(
+    await _hive.recipeBox.put(
         recipe.recipe.code ?? recipe.recipe.name ?? "", recipe);
   }
 
@@ -21,35 +21,35 @@ class RecipesDataSource {
     final Map<String, RecipesDBO> entries = {
       for (var r in recipes) (r.recipe.code ?? r.recipe.name ?? ""): r
     };
-    await _recipesBox.putAll(entries);
+    await _hive.recipeBox.putAll(entries);
   }
 
   /// Supprimer une recette à partir de son code ou nom
   Future<void> deleteRecipe(String key) async {
     log.fine('Deleting recipe with key $key');
-    await _recipesBox.delete(key);
+    await _hive.recipeBox.delete(key);
   }
 
   /// Mettre à jour une recette (remplace tout l'objet)
   Future<void> updateRecipe(String key, RecipesDBO updatedRecipe) async {
     log.fine('Updating recipe with key $key');
-    await _recipesBox.put(key, updatedRecipe);
+    await _hive.recipeBox.put(key, updatedRecipe);
   }
 
   /// Obtenir une recette à partir de son code ou nom
   Future<RecipesDBO?> getRecipeByKey(String key) async {
-    return _recipesBox.get(key);
+    return _hive.recipeBox.get(key);
   }
 
   /// Obtenir toutes les recettes
   Future<List<RecipesDBO>> getAllRecipes() async {
-    return _recipesBox.values.toList();
+    return _hive.recipeBox.values.toList();
   }
 
   /// Rechercher une recette par nom (contains)
   Future<List<RecipesDBO>> searchRecipes(String query) async {
     final lowerQuery = query.toLowerCase();
-    return _recipesBox.values
+    return _hive.recipeBox.values
         .where((recipe) =>
             recipe.recipe.name?.toLowerCase().contains(lowerQuery) ?? false)
         .toList();

--- a/lib/core/data/data_source/tracked_day_data_source.dart
+++ b/lib/core/data/data_source/tracked_day_data_source.dart
@@ -1,38 +1,38 @@
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
 import 'package:opennutritracker/core/utils/extensions.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class TrackedDayDataSource {
   final log = Logger('TrackedDayDataSource');
-  final Box<TrackedDayDBO> _trackedDayBox;
+  final HiveDBProvider _hive;
 
-  TrackedDayDataSource(this._trackedDayBox);
+  TrackedDayDataSource(this._hive);
 
   Future<void> saveTrackedDay(TrackedDayDBO trackedDayDBO) async {
     log.fine('Updating tracked day in db');
-    _trackedDayBox.put(trackedDayDBO.day.toParsedDay(), trackedDayDBO);
+    _hive.trackedDayBox.put(trackedDayDBO.day.toParsedDay(), trackedDayDBO);
   }
 
   Future<void> saveAllTrackedDays(List<TrackedDayDBO> trackedDayDBOList) async {
     log.fine('Updating tracked days in db');
-    _trackedDayBox.putAll({
+    _hive.trackedDayBox.putAll({
       for (var trackedDayDBO in trackedDayDBOList)
         trackedDayDBO.day.toParsedDay(): trackedDayDBO
     });
   }
 
   Future<List<TrackedDayDBO>> getAllTrackedDays() async {
-    return _trackedDayBox.values.toList();
+    return _hive.trackedDayBox.values.toList();
   }
 
   Future<TrackedDayDBO?> getTrackedDay(DateTime day) async {
-    return _trackedDayBox.get(day.toParsedDay());
+    return _hive.trackedDayBox.get(day.toParsedDay());
   }
 
   Future<List<TrackedDayDBO>> getTrackedDaysInRange(
       DateTime start, DateTime end) async {
-    List<TrackedDayDBO> trackedDays = _trackedDayBox.values
+    List<TrackedDayDBO> trackedDays = _hive.trackedDayBox.values
         .where((trackedDay) =>
             (trackedDay.day.isAfter(start) && trackedDay.day.isBefore(end)))
         .toList();
@@ -40,7 +40,7 @@ class TrackedDayDataSource {
   }
 
   Future<bool> hasTrackedDay(DateTime day) async =>
-      _trackedDayBox.get(day.toParsedDay()) != null;
+      _hive.trackedDayBox.get(day.toParsedDay()) != null;
 
   Future<void> updateDayCalorieGoal(DateTime day, double calorieGoal) async {
     log.fine('Updating tracked day total calories');

--- a/lib/core/data/data_source/user_activity_data_source.dart
+++ b/lib/core/data/data_source/user_activity_data_source.dart
@@ -1,28 +1,28 @@
 import 'package:flutter/material.dart';
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class UserActivityDataSource {
   final log = Logger('UserActivityDataSource');
-  final Box<UserActivityDBO> _userActivityBox;
+  final HiveDBProvider _hive;
 
-  UserActivityDataSource(this._userActivityBox);
+  UserActivityDataSource(this._hive);
 
   Future<void> addUserActivity(UserActivityDBO userActivityDBO) async {
     log.fine('Adding new user activity to db');
-    _userActivityBox.add(userActivityDBO);
+    _hive.userActivityBox.add(userActivityDBO);
   }
 
   Future<void> addAllUserActivities(
       List<UserActivityDBO> userActivityDBOList) async {
     log.fine('Adding new user activities to db');
-    _userActivityBox.addAll(userActivityDBOList);
+    _hive.userActivityBox.addAll(userActivityDBOList);
   }
 
   Future<void> deleteIntakeFromId(String activityId) async {
     log.fine('Deleting activity item from db');
-    _userActivityBox.values
+    _hive.userActivityBox.values
         .where((dbo) => dbo.id == activityId)
         .toList()
         .forEach((element) {
@@ -31,18 +31,18 @@ class UserActivityDataSource {
   }
 
   Future<List<UserActivityDBO>> getAllUserActivities() async {
-    return _userActivityBox.values.toList();
+    return _hive.userActivityBox.values.toList();
   }
   Future<List<UserActivityDBO>> getAllUserActivitiesByDate(
       DateTime dateTime) async {
-    return _userActivityBox.values
+    return _hive.userActivityBox.values
         .where((activity) => DateUtils.isSameDay(dateTime, activity.date))
         .toList();
   }
 
   Future<List<UserActivityDBO>> getRecentlyAddedUserActivity(
       {int number = 20}) async {
-    final userActivities = _userActivityBox.values.toList().reversed;
+    final userActivities = _hive.userActivityBox.values.toList().reversed;
 
     //  sort list by date and filter unique activities
     userActivities

--- a/lib/core/data/data_source/user_data_source.dart
+++ b/lib/core/data/data_source/user_data_source.dart
@@ -1,4 +1,4 @@
-import 'package:hive_flutter/hive_flutter.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 import 'package:logging/logging.dart';
 import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_gender_dbo.dart';
@@ -8,20 +8,20 @@ import 'package:opennutritracker/core/data/dbo/user_weight_goal_dbo.dart';
 class UserDataSource {
   static const _userKey = "UserKey";
   final log = Logger('UserDataSource');
-  final Box<UserDBO> _userBox;
+  final HiveDBProvider _hive;
 
-  UserDataSource(this._userBox);
+  UserDataSource(this._hive);
 
   Future<void> saveUserData(UserDBO userDBO) async {
     log.fine('Updating user in db');
-    _userBox.put(_userKey, userDBO);
+    _hive.userBox.put(_userKey, userDBO);
   }
 
-  Future<bool> hasUserData() async => _userBox.containsKey(_userKey);
+  Future<bool> hasUserData() async => _hive.userBox.containsKey(_userKey);
 
   // TODO remove dummy data
   Future<UserDBO> getUserData() async {
-    return _userBox.get(_userKey) ??
+    return _hive.userBox.get(_userKey) ??
         UserDBO(
             birthday: DateTime(2000, 1, 1),
             heightCM: 180,

--- a/lib/core/data/data_source/user_weight_data_source.dart
+++ b/lib/core/data/data_source/user_weight_data_source.dart
@@ -1,10 +1,10 @@
-import 'package:hive_flutter/hive_flutter.dart';
 import 'package:opennutritracker/core/data/data_source/user_weight_dbo.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class UserWeightDataSource {
-  final Box<UserWeightDbo> _userWeightBox;
+  final HiveDBProvider _hive;
 
-  UserWeightDataSource(this._userWeightBox);
+  UserWeightDataSource(this._hive);
 
   String _normaliseDateToKey(DateTime date) {
     /* Normalizes the given date to midnight for use as a unique daily key*/
@@ -13,21 +13,21 @@ class UserWeightDataSource {
 
   Future<void> addUserWeight(UserWeightDbo userWeightDbo) async {
     /* Use the date at midnight as the key to ensure one entry per day */
-    await _userWeightBox.put(
+    await _hive.userWeightBox.put(
         _normaliseDateToKey(userWeightDbo.date), userWeightDbo);
   }
 
   Future<void> deleteUserWeightByDate(DateTime dateTime) async {
-    await _userWeightBox.delete(_normaliseDateToKey(dateTime));
+    await _hive.userWeightBox.delete(_normaliseDateToKey(dateTime));
   }
 
   Future<UserWeightDbo?> getUserWeightByDate(DateTime dateTime) async {
-    return _userWeightBox.get(_normaliseDateToKey(dateTime));
+    return _hive.userWeightBox.get(_normaliseDateToKey(dateTime));
   }
 
   Future<UserWeightDbo?> getLastSavedUserWeight(DateTime date) async {
-    for (int i = _userWeightBox.length - 1; i >= 0; i--) {
-      final dbo = _userWeightBox.getAt(i);
+    for (int i = _hive.userWeightBox.length - 1; i >= 0; i--) {
+      final dbo = _hive.userWeightBox.getAt(i);
       if (dbo != null && !dbo.date.isAfter(date)) {
         return dbo;
       }
@@ -36,13 +36,13 @@ class UserWeightDataSource {
   }
 
   Future<List<UserWeightDbo>> getAllUserWeights() async {
-    return _userWeightBox.values.toList();
+    return _hive.userWeightBox.values.toList();
   }
 
   Future<void> addAllUserWeights(List<UserWeightDbo> userWeightDbos) async {
     final Map<String, UserWeightDbo> mapped = {
       for (var dbo in userWeightDbos) _normaliseDateToKey(dbo.date): dbo
     };
-    await _userWeightBox.putAll(mapped);
+    await _hive.userWeightBox.putAll(mapped);
   }
 }

--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -41,7 +41,6 @@ import 'package:opennutritracker/core/domain/usecase/update_intake_usecase.dart'
 import 'package:opennutritracker/core/utils/env.dart';
 import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 import 'package:opennutritracker/core/utils/ont_image_cache_manager.dart';
-import 'package:opennutritracker/core/utils/secure_app_storage_provider.dart';
 import 'package:opennutritracker/features/activity_detail/presentation/bloc/activity_detail_bloc.dart';
 import 'package:opennutritracker/features/add_activity/presentation/bloc/activities_bloc.dart';
 import 'package:opennutritracker/features/add_activity/presentation/bloc/recent_activities_bloc.dart';
@@ -74,165 +73,230 @@ import 'package:opennutritracker/features/settings/presentation/bloc/settings_bl
 import 'package:supabase_flutter/supabase_flutter.dart';
 
 final locator = GetIt.instance;
+const _userScope = 'user_scope';
 
 Future<void> initLocator() async {
   // Backend
   await Supabase.initialize(
-      url: Env.supabaseProjectUrl, anonKey: Env.supabaseProjectAnonKey);
+    url: Env.supabaseProjectUrl,
+    anonKey: Env.supabaseProjectAnonKey,
+  );
 
   locator.registerLazySingleton<SupabaseClient>(() => Supabase.instance.client);
 
   // Init secure storage and Hive database;
-  final secureAppStorageProvider = SecureAppStorageProvider();
   final hiveDBProvider = HiveDBProvider();
-  await hiveDBProvider
-      .initHiveDB(await secureAppStorageProvider.getHiveEncryptionKey());
+  await hiveDBProvider.initForUser(
+    Supabase.instance.client.auth.currentUser?.id,
+  );
+
+  locator.registerSingleton<HiveDBProvider>(hiveDBProvider);
 
   // Cache manager
-  locator
-      .registerLazySingleton<CacheManager>(() => OntImageCacheManager.instance);
+  locator.registerLazySingleton<CacheManager>(
+    () => OntImageCacheManager.instance,
+  );
 
-  // BLoCs
-  locator.registerLazySingleton<OnboardingBloc>(
-      () => OnboardingBloc(locator(), locator()));
-  locator.registerLazySingleton<HomeBloc>(() => HomeBloc(
-      locator(),
-      locator(),
-      locator(),
-      locator(),
-      locator(),
-      locator(),
-      locator(),
-      locator(),
-      locator(),
-      locator(),
-      locator(),
-      locator()));
+  await registerUserScope(hiveDBProvider);
+}
 
-  locator.registerLazySingleton(() => DiaryBloc(locator(), locator()));
-  locator.registerLazySingleton(() => CalendarDayBloc(locator(), locator(),
-      locator(), locator(), locator(), locator(), locator()));
-  locator.registerLazySingleton<ProfileBloc>(
-      () => ProfileBloc(locator(), locator(), locator(), locator(), locator()));
-  locator.registerLazySingleton(() =>
-      SettingsBloc(locator(), locator(), locator(), locator(), locator()));
-  locator.registerFactory(() =>
-      ExportImportBloc(locator(), locator(), locator()));
-  locator
-      .registerLazySingleton<CreateMealBloc>(() => CreateMealBloc(locator()));
+Future<void> registerUserScope(HiveDBProvider hive) async {
+// --- si un user-scope est déjà présent, on le détruit ---
+  if (locator.currentScopeName == _userScope) {
+    await locator.popScope(); // ferme les anciens singletons + dispose()
+  }
 
-  locator.registerFactory<ActivitiesBloc>(() => ActivitiesBloc(locator()));
-  locator.registerFactory<RecentActivitiesBloc>(
-      () => RecentActivitiesBloc(locator()));
-  locator.registerFactory<ActivityDetailBloc>(() => ActivityDetailBloc(
-      locator(), locator(), locator(), locator(), locator()));
-  locator.registerFactory<MealDetailBloc>(
-      () => MealDetailBloc(locator(), locator(), locator(), locator()));
-  locator.registerFactory<ScannerBloc>(() => ScannerBloc(locator(), locator()));
-  locator.registerFactory<EditMealBloc>(() => EditMealBloc(locator()));
-  locator.registerFactory<AddMealBloc>(() => AddMealBloc(locator()));
-  locator
-      .registerFactory<ProductsBloc>(() => ProductsBloc(locator(), locator()));
-  locator.registerFactory<FoodBloc>(() => FoodBloc(locator(), locator()));
-  locator.registerFactory(() => RecentMealBloc(locator(), locator()));
-  locator
-      .registerFactory(() => RecipeSearchBloc(locator(), locator(), locator()));
-  locator.registerLazySingleton(() => WeightBloc());
-
-  // UseCases
-  locator.registerLazySingleton<GetConfigUsecase>(
-      () => GetConfigUsecase(locator()));
-  locator.registerLazySingleton<AddConfigUsecase>(
-      () => AddConfigUsecase(locator()));
-  locator
-      .registerLazySingleton<GetUserUsecase>(() => GetUserUsecase(locator()));
-  locator
-      .registerLazySingleton<AddUserUsecase>(() => AddUserUsecase(locator()));
-  locator.registerLazySingleton<SearchProductsUseCase>(
-      () => SearchProductsUseCase(locator()));
-  locator.registerLazySingleton<SearchProductByBarcodeUseCase>(
-      () => SearchProductByBarcodeUseCase(locator()));
-  locator.registerLazySingleton<GetIntakeUsecase>(
-      () => GetIntakeUsecase(locator()));
-  locator.registerLazySingleton<AddIntakeUsecase>(
-      () => AddIntakeUsecase(locator()));
-  locator.registerLazySingleton<DeleteIntakeUsecase>(
-      () => DeleteIntakeUsecase(locator()));
-  locator.registerLazySingleton<DeleteRecipeUsecase>(
-      () => DeleteRecipeUsecase(locator()));
-  locator.registerLazySingleton<UpdateIntakeUsecase>(
-      () => UpdateIntakeUsecase(locator()));
-  locator.registerLazySingleton<AddRecipeUsecase>(
-      () => AddRecipeUsecase(locator()));
-  locator.registerLazySingleton<GetRecipeUsecase>(
-      () => GetRecipeUsecase(locator()));
-  locator.registerLazySingleton<GetUserActivityUsecase>(
-      () => GetUserActivityUsecase(locator()));
-  locator.registerLazySingleton<AddUserActivityUsecase>(
-      () => AddUserActivityUsecase(locator()));
-  locator.registerLazySingleton<DeleteUserActivityUsecase>(
-      () => DeleteUserActivityUsecase(locator()));
-  locator.registerLazySingleton<GetPhysicalActivityUsecase>(
-      () => GetPhysicalActivityUsecase(locator()));
-  locator.registerLazySingleton<GetTrackedDayUsecase>(
-      () => GetTrackedDayUsecase(locator()));
-  locator.registerLazySingleton<AddTrackedDayUsecase>(
-      () => AddTrackedDayUsecase(locator()));
-  locator.registerLazySingleton(
-      () => GetKcalGoalUsecase(locator(), locator(), locator()));
-  locator.registerLazySingleton(() => GetMacroGoalUsecase(locator()));
-  locator.registerLazySingleton(
-      () => ExportDataUsecase(locator(), locator(), locator(), locator()));
-  locator.registerLazySingleton(
-      () => ImportDataUsecase(locator(), locator(), locator(), locator()));
-  locator.registerLazySingleton(
-      () => ExportDataSupabaseUsecase(
-          locator(), locator(), locator(), locator(), locator()));
-  locator.registerLazySingleton<AddWeightUsecase>(
-      () => AddWeightUsecase(locator()));
-  locator.registerLazySingleton<GetWeightUsecase>(() => GetWeightUsecase());
-  locator.registerLazySingleton<DeleteUserWeightUsecase>(
-      () => DeleteUserWeightUsecase(locator()));
-
-  // Repositories
-  locator.registerLazySingleton(() => ConfigRepository(locator()));
-  locator
-      .registerLazySingleton<UserRepository>(() => UserRepository(locator()));
-  locator.registerLazySingleton<IntakeRepository>(
-      () => IntakeRepository(locator()));
-  locator.registerLazySingleton<RecipeRepository>(
-      () => RecipeRepository(locator()));
-  locator.registerLazySingleton<ProductsRepository>(
-      () => ProductsRepository(locator(), locator(), locator()));
-  locator.registerLazySingleton<UserActivityRepository>(
-      () => UserActivityRepository(locator()));
-  locator.registerLazySingleton<PhysicalActivityRepository>(
-      () => PhysicalActivityRepository(locator()));
-  locator.registerLazySingleton<TrackedDayRepository>(
-      () => TrackedDayRepository(locator()));
-  locator.registerLazySingleton<UserWeightRepository>(
-      () => UserWeightRepository(locator()));
+// --- nouveau scope isolé pour l’utilisateur courant ---
+  locator.pushNewScope(
+    scopeName: _userScope, // nom pour le retrouver la prochaine fois
+  );
 
   // DataSources
-  locator
-      .registerLazySingleton(() => ConfigDataSource(hiveDBProvider.configBox));
-  locator.registerLazySingleton<UserDataSource>(
-      () => UserDataSource(hiveDBProvider.userBox));
-  locator.registerLazySingleton<IntakeDataSource>(
-      () => IntakeDataSource(hiveDBProvider.intakeBox));
-  locator.registerLazySingleton<RecipesDataSource>(
-      () => RecipesDataSource(hiveDBProvider.recipeBox));
-  locator.registerLazySingleton<UserActivityDataSource>(
-      () => UserActivityDataSource(hiveDBProvider.userActivityBox));
-  locator.registerLazySingleton<PhysicalActivityDataSource>(
-      () => PhysicalActivityDataSource());
+  locator.registerLazySingleton(() => ConfigDataSource(hive));
+  locator.registerLazySingleton<UserDataSource>(() => UserDataSource(hive));
+  locator.registerLazySingleton(() => IntakeDataSource(hive));
+  locator.registerLazySingleton(() => RecipesDataSource(hive));
+  locator.registerLazySingleton(() => UserActivityDataSource(hive));
+  locator.registerLazySingleton(() => PhysicalActivityDataSource());
+  locator.registerLazySingleton(() => TrackedDayDataSource(hive));
+  locator.registerLazySingleton(() => UserWeightDataSource(hive));
   locator.registerLazySingleton<OFFDataSource>(() => OFFDataSource());
   locator.registerLazySingleton<FDCDataSource>(() => FDCDataSource());
   locator.registerLazySingleton<SpFdcDataSource>(() => SpFdcDataSource());
+
+  // Repositories
+  locator.registerLazySingleton(() => ConfigRepository(locator()));
+  locator.registerLazySingleton<UserRepository>(
+    () => UserRepository(locator()),
+  );
+  locator.registerLazySingleton(() => IntakeRepository(locator()));
+  locator.registerLazySingleton(() => RecipeRepository(locator()));
   locator.registerLazySingleton(
-      () => TrackedDayDataSource(hiveDBProvider.trackedDayBox));
+    () => ProductsRepository(locator(), locator(), locator()),
+  );
+  locator.registerLazySingleton(() => UserActivityRepository(locator()));
+  locator.registerLazySingleton(() => PhysicalActivityRepository(locator()));
+  locator.registerLazySingleton(() => TrackedDayRepository(locator()));
+  locator.registerLazySingleton(() => UserWeightRepository(locator()));
+
+  // UseCases
+  locator.registerLazySingleton<GetConfigUsecase>(
+    () => GetConfigUsecase(locator()),
+  );
+  locator.registerLazySingleton<AddConfigUsecase>(
+    () => AddConfigUsecase(locator()),
+  );
+  locator.registerLazySingleton<GetUserUsecase>(
+    () => GetUserUsecase(locator()),
+  );
+  locator.registerLazySingleton<AddUserUsecase>(
+    () => AddUserUsecase(locator()),
+  );
+  locator.registerLazySingleton<SearchProductsUseCase>(
+    () => SearchProductsUseCase(locator()),
+  );
+  locator.registerLazySingleton<SearchProductByBarcodeUseCase>(
+    () => SearchProductByBarcodeUseCase(locator()),
+  );
+  locator.registerLazySingleton<GetIntakeUsecase>(
+    () => GetIntakeUsecase(locator()),
+  );
+  locator.registerLazySingleton<AddIntakeUsecase>(
+    () => AddIntakeUsecase(locator()),
+  );
+  locator.registerLazySingleton<DeleteIntakeUsecase>(
+    () => DeleteIntakeUsecase(locator()),
+  );
+  locator.registerLazySingleton<DeleteRecipeUsecase>(
+    () => DeleteRecipeUsecase(locator()),
+  );
+  locator.registerLazySingleton<UpdateIntakeUsecase>(
+    () => UpdateIntakeUsecase(locator()),
+  );
+  locator.registerLazySingleton<AddRecipeUsecase>(
+    () => AddRecipeUsecase(locator()),
+  );
+  locator.registerLazySingleton<GetRecipeUsecase>(
+    () => GetRecipeUsecase(locator()),
+  );
+  locator.registerLazySingleton<GetUserActivityUsecase>(
+    () => GetUserActivityUsecase(locator()),
+  );
+  locator.registerLazySingleton<AddUserActivityUsecase>(
+    () => AddUserActivityUsecase(locator()),
+  );
+  locator.registerLazySingleton<DeleteUserActivityUsecase>(
+    () => DeleteUserActivityUsecase(locator()),
+  );
+  locator.registerLazySingleton<GetPhysicalActivityUsecase>(
+    () => GetPhysicalActivityUsecase(locator()),
+  );
+  locator.registerLazySingleton<GetTrackedDayUsecase>(
+    () => GetTrackedDayUsecase(locator()),
+  );
+  locator.registerLazySingleton<AddTrackedDayUsecase>(
+    () => AddTrackedDayUsecase(locator()),
+  );
   locator.registerLazySingleton(
-      () => UserWeightDataSource(hiveDBProvider.userWeightBox));
+    () => GetKcalGoalUsecase(locator(), locator(), locator()),
+  );
+  locator.registerLazySingleton(() => GetMacroGoalUsecase(locator()));
+  locator.registerLazySingleton(
+    () => ExportDataUsecase(locator(), locator(), locator(), locator()),
+  );
+  locator.registerLazySingleton(
+    () => ImportDataUsecase(locator(), locator(), locator(), locator()),
+  );
+  locator.registerLazySingleton(
+    () => ExportDataSupabaseUsecase(
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+    ),
+  );
+  locator.registerLazySingleton<AddWeightUsecase>(
+    () => AddWeightUsecase(locator()),
+  );
+  locator.registerLazySingleton<GetWeightUsecase>(() => GetWeightUsecase());
+  locator.registerLazySingleton<DeleteUserWeightUsecase>(
+    () => DeleteUserWeightUsecase(locator()),
+  );
+
+  // BLoCs
+  locator.registerLazySingleton<OnboardingBloc>(
+    () => OnboardingBloc(locator(), locator()),
+  );
+  locator.registerLazySingleton<HomeBloc>(
+    () => HomeBloc(
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+    ),
+  );
+  locator.registerLazySingleton(() => DiaryBloc(locator(), locator()));
+  locator.registerLazySingleton(
+    () => CalendarDayBloc(
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+    ),
+  );
+  locator.registerLazySingleton<ProfileBloc>(
+    () => ProfileBloc(locator(), locator(), locator(), locator(), locator()),
+  );
+  locator.registerLazySingleton(
+    () => SettingsBloc(locator(), locator(), locator(), locator(), locator()),
+  );
+  locator.registerFactory(
+    () => ExportImportBloc(locator(), locator(), locator()),
+  );
+  locator.registerLazySingleton<CreateMealBloc>(
+    () => CreateMealBloc(locator()),
+  );
+
+  locator.registerFactory<ActivitiesBloc>(() => ActivitiesBloc(locator()));
+  locator.registerFactory<RecentActivitiesBloc>(
+    () => RecentActivitiesBloc(locator()),
+  );
+  locator.registerFactory<ActivityDetailBloc>(
+    () => ActivityDetailBloc(
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+    ),
+  );
+  locator.registerFactory<MealDetailBloc>(
+    () => MealDetailBloc(locator(), locator(), locator(), locator()),
+  );
+  locator.registerFactory<ScannerBloc>(() => ScannerBloc(locator(), locator()));
+  locator.registerFactory<EditMealBloc>(() => EditMealBloc(locator()));
+  locator.registerFactory<AddMealBloc>(() => AddMealBloc(locator()));
+  locator.registerFactory<ProductsBloc>(
+    () => ProductsBloc(locator(), locator()),
+  );
+  locator.registerFactory<FoodBloc>(() => FoodBloc(locator(), locator()));
+  locator.registerFactory(() => RecentMealBloc(locator(), locator()));
+  locator.registerFactory(
+    () => RecipeSearchBloc(locator(), locator(), locator()),
+  );
+  locator.registerLazySingleton(() => WeightBloc());
 
   await _initializeConfig(locator());
 }

--- a/lib/features/auth/auth_safe_sign_out.dart
+++ b/lib/features/auth/auth_safe_sign_out.dart
@@ -7,6 +7,7 @@ import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/settings/domain/usecase/export_data_supabase_usecase.dart';
 import 'package:opennutritracker/features/settings/presentation/bloc/export_import_bloc.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 final _log = Logger('AuthSafeSignOut');
 
@@ -34,8 +35,10 @@ Future<void> safeSignOut(BuildContext context) async {
         ExportImportBloc.trackedDayJsonFileName,
         ExportImportBloc.userWeightJsonFileName,
       );
-      _log.log(ok ? Level.FINE : Level.WARNING,
-          ok ? 'Export réussi' : 'Export échoué – on continue quand même');
+      _log.log(
+        ok ? Level.FINE : Level.WARNING,
+        ok ? 'Export réussi' : 'Export échoué – on continue quand même',
+      );
     } else {
       _log.warning('safeSignOut appelé sans session active');
     }
@@ -50,10 +53,16 @@ Future<void> safeSignOut(BuildContext context) async {
       _log.warning('Erreur pendant signOut', err, stack);
     }
 
+    final hive = locator<HiveDBProvider>();
+    await hive.initForUser(null);
+    await registerUserScope(hive);
+
     // ▸ 2. Ferme le loader
     if (context.mounted) {
-      Navigator.of(context, rootNavigator: true)
-          .popUntil((route) => route.isFirst);
+      Navigator.of(
+        context,
+        rootNavigator: true,
+      ).popUntil((route) => route.isFirst);
     }
 
     // ▸ 3. Redirige vers la page login

--- a/test/unit_test/add_recipe_usecase_test.dart
+++ b/test/unit_test/add_recipe_usecase_test.dart
@@ -3,6 +3,7 @@ import 'dart:io';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:opennutritracker/core/data/data_source/recipe_data_source.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 import 'package:opennutritracker/core/data/dbo/intake_recipe_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
@@ -19,6 +20,7 @@ void main() {
     late Directory tempDir;
     late Box<RecipesDBO> box;
     late AddRecipeUsecase usecase;
+    late HiveDBProvider hive;
 
     setUp(() async {
       TestWidgetsFlutterBinding.ensureInitialized();
@@ -33,7 +35,9 @@ void main() {
       Hive.registerAdapter(MealOrRecipeDBOAdapter());
 
       box = await Hive.openBox<RecipesDBO>('recipes_test');
-      final repo = RecipeRepository(RecipesDataSource(box));
+      hive = HiveDBProvider();
+      hive.recipeBox = box;
+      final repo = RecipeRepository(RecipesDataSource(hive));
       usecase = AddRecipeUsecase(repo);
     });
 

--- a/test/unit_test/intake_repository_test.dart
+++ b/test/unit_test/intake_repository_test.dart
@@ -9,6 +9,7 @@ import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
 import 'package:opennutritracker/core/data/repository/intake_repository.dart';
 import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/core/domain/entity/intake_type_entity.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 import '../fixture/meal_entity_fixtures.dart';
 
@@ -34,7 +35,9 @@ void main() {
     test('returns last added first', () async {
       final box = await Hive.openBox<IntakeDBO>('intake_test');
 
-      final repo = IntakeRepository(IntakeDataSource(box));
+      final hive = HiveDBProvider();
+      hive.intakeBox = box;
+      final repo = IntakeRepository(IntakeDataSource(hive));
 
 
       await repo.addIntake(IntakeEntity(

--- a/test/unit_test/recipe_creation_integration_test.dart
+++ b/test/unit_test/recipe_creation_integration_test.dart
@@ -4,6 +4,7 @@ import 'package:flutter_test/flutter_test.dart';
 import 'package:hive/hive.dart';
 import 'package:mocktail/mocktail.dart';
 import 'package:opennutritracker/core/data/data_source/recipe_data_source.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 import 'package:opennutritracker/core/data/dbo/intake_recipe_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
@@ -44,7 +45,9 @@ void main() {
       Hive.registerAdapter(MealOrRecipeDBOAdapter());
 
       box = await Hive.openBox<RecipesDBO>('recipes_test');
-      final dataSource = RecipesDataSource(box);
+      final hive = HiveDBProvider();
+      hive.recipeBox = box;
+      final dataSource = RecipesDataSource(hive);
       final repo = RecipeRepository(dataSource);
       addUsecase = AddRecipeUsecase(repo);
 

--- a/test/unit_test/recipe_repository_test.dart
+++ b/test/unit_test/recipe_repository_test.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
 import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/core/domain/usecase/add_recipe_usecase.dart';
 import 'package:opennutritracker/core/domain/usecase/delete_recipe_usecase.dart';
@@ -36,8 +37,9 @@ void main() {
       Hive.registerAdapter(MealOrRecipeDBOAdapter());
 
       box = await Hive.openBox<RecipesDBO>('recipes_test');
-
-      final dataSource = RecipesDataSource(box);
+      final hive = HiveDBProvider();
+      hive.recipeBox = box;
+      final dataSource = RecipesDataSource(hive);
       final repo = RecipeRepository(dataSource);
       final addRecipeUsecase = AddRecipeUsecase(repo);
       final deleteRecipeUsecase = DeleteRecipeUsecase(repo);
@@ -99,7 +101,9 @@ void main() {
       Hive.init(tempDir.path);
 
       box = await Hive.openBox<RecipesDBO>('recipes_test');
-      final dataSource = RecipesDataSource(box);
+      final hive = HiveDBProvider();
+      hive.recipeBox = box;
+      final dataSource = RecipesDataSource(hive);
       final repo = RecipeRepository(dataSource);
       locator.registerSingleton<AddRecipeUsecase>(AddRecipeUsecase(repo));
       locator.registerSingleton<DeleteRecipeUsecase>(DeleteRecipeUsecase(repo));

--- a/test/unit_test/tracked_day_change_isolate_test.dart
+++ b/test/unit_test/tracked_day_change_isolate_test.dart
@@ -11,6 +11,7 @@ import 'package:opennutritracker/features/sync/tracked_day_change_isolate.dart';
 import 'package:opennutritracker/features/sync/supabase_client.dart';
 import 'package:opennutritracker/core/data/repository/tracked_day_repository.dart';
 import 'package:opennutritracker/core/data/data_source/tracked_day_data_source.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:mocktail/mocktail.dart';
 
@@ -68,9 +69,11 @@ void main() {
         Hive.registerAdapter(TrackedDayDBOAdapter());
       }
       box = await Hive.openBox<TrackedDayDBO>('tracked_day_test');
+      final hive = HiveDBProvider();
+      hive.trackedDayBox = box;
 
       // Initialize repository with the Hive box
-      repo = TrackedDayRepository(TrackedDayDataSource(box));
+      repo = TrackedDayRepository(TrackedDayDataSource(hive));
 
       // Setup mock Supabase client using mock-supabase-http-client
       mockHttpClient = MockSupabaseHttpClient();


### PR DESCRIPTION
## Summary
- refactor all local data sources to depend on `HiveDBProvider`
- update service locator registrations accordingly
- fix unit tests to supply a `HiveDBProvider` instead of raw Hive boxes
- introduce `registerUserScope` for GetIt and scope all user data services
- re-register the user scope after login/logout

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68692faa4bec8321aee7f87593cf6fe8