### PR TITLE
Add Supabase import with conflict handling

### DIFF
--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -68,6 +68,7 @@ import 'package:opennutritracker/features/scanner/presentation/scanner_bloc.dart
 import 'package:opennutritracker/features/settings/domain/usecase/export_data_usecase.dart';
 import 'package:opennutritracker/features/settings/domain/usecase/import_data_usecase.dart';
 import 'package:opennutritracker/features/settings/domain/usecase/export_data_supabase_usecase.dart';
+import 'package:opennutritracker/features/settings/domain/usecase/import_data_supabase_usecase.dart';
 import 'package:opennutritracker/features/settings/presentation/bloc/export_import_bloc.dart';
 import 'package:opennutritracker/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
@@ -217,6 +218,15 @@ Future<void> registerUserScope(HiveDBProvider hive) async {
       locator(),
     ),
   );
+  locator.registerLazySingleton(
+    () => ImportDataSupabaseUsecase(
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+    ),
+  );
 
   locator.registerLazySingleton<AddWeightUsecase>(
     () => AddWeightUsecase(locator()),
@@ -265,7 +275,12 @@ Future<void> registerUserScope(HiveDBProvider hive) async {
     () => SettingsBloc(locator(), locator(), locator(), locator(), locator()),
   );
   locator.registerFactory(
-    () => ExportImportBloc(locator(), locator(), locator()),
+    () => ExportImportBloc(
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+    ),
   );
   locator.registerLazySingleton<CreateMealBloc>(
     () => CreateMealBloc(locator()),

--- a/lib/features/settings/domain/usecase/import_data_supabase_usecase.dart
+++ b/lib/features/settings/domain/usecase/import_data_supabase_usecase.dart
@@ -1,0 +1,166 @@
+import 'dart:convert';
+import 'package:archive/archive.dart';
+import 'package:logging/logging.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:opennutritracker/core/data/data_source/user_activity_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/intake_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/tracked_day_dbo.dart';
+import 'package:opennutritracker/core/data/data_source/user_weight_dbo.dart';
+import 'package:opennutritracker/core/data/repository/intake_repository.dart';
+import 'package:opennutritracker/core/data/repository/tracked_day_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_weight_repository.dart';
+import 'package:opennutritracker/core/domain/entity/user_activity_entity.dart';
+import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
+
+/// Imports user data from a zip stored on Supabase storage.
+/// Existing entries are replaced if the incoming entry has a more recent
+/// `updatedAt` field.
+class ImportDataSupabaseUsecase {
+  final UserActivityRepository _userActivityRepository;
+  final IntakeRepository _intakeRepository;
+  final TrackedDayRepository _trackedDayRepository;
+  final UserWeightRepository _userWeightRepository;
+  final SupabaseClient _client;
+  final _log = Logger('ImportDataSupabaseUsecase');
+
+  ImportDataSupabaseUsecase(
+    this._userActivityRepository,
+    this._intakeRepository,
+    this._trackedDayRepository,
+    this._userWeightRepository,
+    this._client,
+  );
+
+  Future<bool> importData(
+    String exportZipFileName,
+    String userActivityJsonFileName,
+    String userIntakeJsonFileName,
+    String trackedDayJsonFileName,
+    String userWeightJsonFileName,
+  ) async {
+    try {
+      final userId = _client.auth.currentUser?.id;
+      if (userId == null) {
+        _log.warning('No Supabase session – aborting import');
+        return false;
+      }
+
+      final filePath = '$userId/$exportZipFileName';
+      final data = await _client.storage.from('exports').download(filePath);
+      final archive = ZipDecoder().decodeBytes(data);
+
+      // ----- USER ACTIVITY -----
+      final userActivityFile = archive.findFile(userActivityJsonFileName);
+      if (userActivityFile == null) {
+        throw Exception('User activity file not found');
+      }
+      final userActivityJsonString =
+          utf8.decode(userActivityFile.content as List<int>);
+      final userActivityList = (jsonDecode(userActivityJsonString) as List)
+          .cast<Map<String, dynamic>>();
+      final userActivityDBOs =
+          userActivityList.map((e) => UserActivityDBO.fromJson(e)).toList();
+
+      final existingActivities = await _userActivityRepository.getAllUserActivityDBO();
+      final activityMap = {
+        for (final a in existingActivities) a.id: a
+      };
+      for (final dbo in userActivityDBOs) {
+        final current = activityMap[dbo.id];
+        if (current == null) {
+          await _userActivityRepository.addAllUserActivityDBOs([dbo]);
+        } else if (dbo.updatedAt.isAfter(current.updatedAt)) {
+          await _userActivityRepository.deleteUserActivity(
+              UserActivityEntity.fromUserActivityDBO(current));
+          await _userActivityRepository.addAllUserActivityDBOs([dbo]);
+        }
+      }
+
+      // ----- INTAKES -----
+      final intakeFile = archive.findFile(userIntakeJsonFileName);
+      if (intakeFile == null) {
+        throw Exception('Intake file not found');
+      }
+      final intakeJsonString = utf8.decode(intakeFile.content as List<int>);
+      final intakeList =
+          (jsonDecode(intakeJsonString) as List).cast<Map<String, dynamic>>();
+      final intakeDBOs = intakeList.map((e) => IntakeDBO.fromJson(e)).toList();
+
+      final existingIntakes = await _intakeRepository.getAllIntakesDBO();
+      final intakeMap = {for (final i in existingIntakes) i.id: i};
+      for (final dbo in intakeDBOs) {
+        final current = intakeMap[dbo.id];
+        if (current == null) {
+          await _intakeRepository.addAllIntakeDBOs([dbo]);
+        } else if (dbo.updatedAt.isAfter(current.updatedAt)) {
+          await _intakeRepository.deleteIntake(
+              IntakeEntity.fromIntakeDBO(current));
+          await _intakeRepository.addAllIntakeDBOs([dbo]);
+        }
+      }
+
+      // ----- TRACKED DAYS -----
+      final trackedDayFile = archive.findFile(trackedDayJsonFileName);
+      if (trackedDayFile == null) {
+        throw Exception('Tracked day file not found');
+      }
+      final trackedDayJsonString =
+          utf8.decode(trackedDayFile.content as List<int>);
+      final trackedDayList = (jsonDecode(trackedDayJsonString) as List)
+          .cast<Map<String, dynamic>>();
+      final trackedDayDBOs =
+          trackedDayList.map((e) => TrackedDayDBO.fromJson(e)).toList();
+
+      final existingDays = await _trackedDayRepository.getAllTrackedDaysDBO();
+      final dayMap = {
+        for (final d in existingDays) d.day.toIso8601String(): d
+      };
+      final List<TrackedDayDBO> daysToSave = [];
+      for (final dbo in trackedDayDBOs) {
+        final key = dbo.day.toIso8601String();
+        final current = dayMap[key];
+        if (current == null || dbo.updatedAt.isAfter(current.updatedAt)) {
+          daysToSave.add(dbo);
+        }
+      }
+      if (daysToSave.isNotEmpty) {
+        await _trackedDayRepository.addAllTrackedDays(daysToSave);
+      }
+
+      // ----- USER WEIGHT -----
+      final userWeightFile = archive.findFile(userWeightJsonFileName);
+      if (userWeightFile == null) {
+        throw Exception('User weight file not found');
+      }
+      final userWeightJsonString =
+          utf8.decode(userWeightFile.content as List<int>);
+      final userWeightList = (jsonDecode(userWeightJsonString) as List)
+          .cast<Map<String, dynamic>>();
+      final userWeightDBOs =
+          userWeightList.map((e) => UserWeightDbo.fromJson(e)).toList();
+
+      final existingWeights = await _userWeightRepository.getAllUserWeightDBOs();
+      final weightMap = {
+        for (final w in existingWeights)
+          DateTime(w.date.year, w.date.month, w.date.day).toIso8601String(): w
+      };
+      for (final dbo in userWeightDBOs) {
+        final key =
+            DateTime(dbo.date.year, dbo.date.month, dbo.date.day).toIso8601String();
+        final current = weightMap[key];
+        if (current == null) {
+          await _userWeightRepository.addAllUserWeightDBOs([dbo]);
+        } else if (dbo.updatedAt.isAfter(current.updatedAt)) {
+          await _userWeightRepository.deleteUserWeightByDate(current.date);
+          await _userWeightRepository.addAllUserWeightDBOs([dbo]);
+        }
+      }
+
+      return true;
+    } catch (e, stack) {
+      _log.severe('Failed to import from Supabase', e, stack);
+      return false;
+    }
+  }
+}

--- a/lib/features/settings/presentation/bloc/export_import_bloc.dart
+++ b/lib/features/settings/presentation/bloc/export_import_bloc.dart
@@ -3,6 +3,7 @@ import 'package:flutter_bloc/flutter_bloc.dart';
 import 'package:opennutritracker/features/settings/domain/usecase/export_data_usecase.dart';
 import 'package:opennutritracker/features/settings/domain/usecase/import_data_usecase.dart';
 import 'package:opennutritracker/features/settings/domain/usecase/export_data_supabase_usecase.dart';
+import 'package:opennutritracker/features/settings/domain/usecase/import_data_supabase_usecase.dart';
 
 part 'export_import_event.dart';
 
@@ -18,9 +19,10 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
   final ExportDataUsecase _exportDataUsecase;
   final ImportDataUsecase _importDataUsecase;
   final ExportDataSupabaseUsecase _exportDataSupabaseUsecase;
+  final ImportDataSupabaseUsecase _importDataSupabaseUsecase;
 
   ExportImportBloc(this._exportDataUsecase, this._importDataUsecase,
-      this._exportDataSupabaseUsecase)
+      this._exportDataSupabaseUsecase, this._importDataSupabaseUsecase)
       : super(ExportImportInitial()) {
     on<ExportDataEvent>((event, emit) async {
       try {
@@ -79,6 +81,28 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
           emit(ExportImportSuccess());
         } else {
           emit(ExportImportInitial());
+        }
+      } catch (e) {
+        emit(ExportImportError());
+      }
+    });
+
+    on<ImportDataSupabaseEvent>((event, emit) async {
+      try {
+        emit(ExportImportLoadingState());
+
+        final result = await _importDataSupabaseUsecase.importData(
+          exportZipFileName,
+          userActivityJsonFileName,
+          userIntakeJsonFileName,
+          trackedDayJsonFileName,
+          userWeightJsonFileName,
+        );
+
+        if (result) {
+          emit(ExportImportSuccess());
+        } else {
+          emit(ExportImportError());
         }
       } catch (e) {
         emit(ExportImportError());

--- a/lib/features/settings/presentation/bloc/export_import_event.dart
+++ b/lib/features/settings/presentation/bloc/export_import_event.dart
@@ -18,3 +18,8 @@ class ExportDataSupabaseEvent extends ExportImportEvent {
   @override
   List<Object?> get props => [];
 }
+
+class ImportDataSupabaseEvent extends ExportImportEvent {
+  @override
+  List<Object?> get props => [];
+}

--- a/lib/features/settings/presentation/widgets/import_supabase_dialog.dart
+++ b/lib/features/settings/presentation/widgets/import_supabase_dialog.dart
@@ -1,0 +1,91 @@
+import 'package:flutter/material.dart';
+import 'package:flutter_bloc/flutter_bloc.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/calendar_day_bloc.dart';
+import 'package:opennutritracker/features/diary/presentation/bloc/diary_bloc.dart';
+import 'package:opennutritracker/features/home/presentation/bloc/home_bloc.dart';
+import 'package:opennutritracker/features/settings/presentation/bloc/export_import_bloc.dart';
+import 'package:opennutritracker/generated/l10n.dart';
+
+class ImportSupabaseDialog extends StatelessWidget {
+  final exportImportBloc = locator<ExportImportBloc>();
+
+  final _homeBloc = locator<HomeBloc>();
+  final _diaryBloc = locator<DiaryBloc>();
+  final _calendarDayBloc = locator<CalendarDayBloc>();
+
+  ImportSupabaseDialog({super.key});
+
+  @override
+  Widget build(BuildContext context) {
+    return AlertDialog(
+      title: Text(S.of(context).importSupabaseLabel,
+          overflow: TextOverflow.ellipsis, maxLines: 2),
+      content: Wrap(children: [
+        Column(
+          children: [
+            BlocBuilder<ExportImportBloc, ExportImportState>(
+                bloc: exportImportBloc,
+                builder: (context, state) {
+                  if (state is ExportImportInitial) {
+                    return Text(
+                      S.of(context).importSupabaseDescription,
+                      overflow: TextOverflow.ellipsis,
+                      maxLines: 15,
+                    );
+                  } else if (state is ExportImportLoadingState) {
+                    return const LinearProgressIndicator();
+                  } else if (state is ExportImportSuccess) {
+                    refreshScreens();
+                    return Row(
+                      children: [
+                        Icon(Icons.check_circle,
+                            color: Theme.of(context).colorScheme.primary),
+                        const SizedBox(width: 8),
+                        Text(
+                          S.of(context).exportImportSuccessLabel,
+                        ),
+                      ],
+                    );
+                  } else if (state is ExportImportError) {
+                    return Row(
+                      crossAxisAlignment: CrossAxisAlignment.start,
+                      children: [
+                        Icon(
+                          Icons.error,
+                          color: Theme.of(context).colorScheme.error,
+                        ),
+                        const SizedBox(width: 8),
+                        Expanded(
+                          child: Text(
+                            S.of(context).exportImportErrorLabel,
+                            softWrap: true,
+                            overflow: TextOverflow.visible,
+                          ),
+                        ),
+                      ],
+                    );
+                  }
+
+                  return const SizedBox.shrink();
+                }),
+          ],
+        ),
+      ]),
+      actions: <Widget>[
+        TextButton(
+          onPressed: () {
+            exportImportBloc.add(ImportDataSupabaseEvent());
+          },
+          child: Text(S.of(context).importAction),
+        ),
+      ],
+    );
+  }
+
+  void refreshScreens() {
+    _homeBloc.add(const LoadItemsEvent());
+    _diaryBloc.add(const LoadDiaryYearEvent());
+    _calendarDayBloc.add(RefreshCalendarDayEvent());
+  }
+}

--- a/lib/features/settings/settings_screen.dart
+++ b/lib/features/settings/settings_screen.dart
@@ -14,6 +14,7 @@ import 'package:opennutritracker/features/profile/presentation/bloc/profile_bloc
 import 'package:opennutritracker/features/settings/presentation/bloc/settings_bloc.dart';
 import 'package:opennutritracker/features/settings/presentation/widgets/export_import_dialog.dart';
 import 'package:opennutritracker/features/settings/presentation/widgets/export_supabase_dialog.dart';
+import 'package:opennutritracker/features/settings/presentation/widgets/import_supabase_dialog.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 import 'package:package_info_plus/package_info_plus.dart';
 import 'package:provider/provider.dart';
@@ -87,6 +88,11 @@ class _SettingsScreenState extends State<SettingsScreen> {
                   leading: const Icon(Icons.cloud_upload_outlined),
                   title: Text(S.of(context).exportSupabaseLabel),
                   onTap: () => _showExportSupabaseDialog(context),
+                ),
+                ListTile(
+                  leading: const Icon(Icons.cloud_download_outlined),
+                  title: Text(S.of(context).importSupabaseLabel),
+                  onTap: () => _showImportSupabaseDialog(context),
                 ),
                 ListTile(
                   leading: const Icon(Icons.description_outlined),
@@ -198,6 +204,13 @@ class _SettingsScreenState extends State<SettingsScreen> {
     showDialog(
       context: context,
       builder: (context) => ExportSupabaseDialog(),
+    );
+  }
+
+  void _showImportSupabaseDialog(BuildContext context) {
+    showDialog(
+      context: context,
+      builder: (context) => ImportSupabaseDialog(),
     );
   }
 

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -190,6 +190,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "heightLabel": MessageLookupByLibrary.simpleMessage("Größe"),
         "homeLabel": MessageLookupByLibrary.simpleMessage("Startseite"),
         "importAction": MessageLookupByLibrary.simpleMessage("Importieren"),
+        "importSupabaseDescription": MessageLookupByLibrary.simpleMessage(
+            "Stelle deine Daten aus einem in Supabase gespeicherten Backup wieder her."),
+        "importSupabaseLabel":
+            MessageLookupByLibrary.simpleMessage("Von Supabase importieren"),
         "infoAddedActivityLabel":
             MessageLookupByLibrary.simpleMessage("Neue Aktivität hinzugefügt"),
         "infoAddedIntakeLabel":

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -191,6 +191,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "heightLabel": MessageLookupByLibrary.simpleMessage("Height"),
         "homeLabel": MessageLookupByLibrary.simpleMessage("Home"),
         "importAction": MessageLookupByLibrary.simpleMessage("Import"),
+        "importSupabaseDescription": MessageLookupByLibrary.simpleMessage(
+            "Restore your data from a backup stored in Supabase."),
+        "importSupabaseLabel":
+            MessageLookupByLibrary.simpleMessage("Import from Supabase"),
         "infoAddedActivityLabel":
             MessageLookupByLibrary.simpleMessage("Added new activity"),
         "infoAddedIntakeLabel":

--- a/lib/generated/intl/messages_fr.dart
+++ b/lib/generated/intl/messages_fr.dart
@@ -198,6 +198,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "heightLabel": MessageLookupByLibrary.simpleMessage("Taille"),
         "homeLabel": MessageLookupByLibrary.simpleMessage("Accueil"),
         "importAction": MessageLookupByLibrary.simpleMessage("Importer"),
+        "importSupabaseDescription": MessageLookupByLibrary.simpleMessage(
+            "Restaurez vos données à partir d\'une sauvegarde stockée sur Supabase."),
+        "importSupabaseLabel":
+            MessageLookupByLibrary.simpleMessage("Importer depuis Supabase"),
         "infoAddedActivityLabel":
             MessageLookupByLibrary.simpleMessage("Nouvelle activité ajoutée"),
         "infoAddedIntakeLabel":

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -184,6 +184,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "heightLabel": MessageLookupByLibrary.simpleMessage("Boy"),
         "homeLabel": MessageLookupByLibrary.simpleMessage("Ana Sayfa"),
         "importAction": MessageLookupByLibrary.simpleMessage("İçe Aktar"),
+        "importSupabaseDescription": MessageLookupByLibrary.simpleMessage(
+            "Verilerinizi Supabase\'de saklanan bir yedekten geri yükleyin."),
+        "importSupabaseLabel":
+            MessageLookupByLibrary.simpleMessage("Supabase\'den İçe Aktar"),
         "infoAddedActivityLabel":
             MessageLookupByLibrary.simpleMessage("Yeni aktivite eklendi"),
         "infoAddedIntakeLabel":

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -1252,6 +1252,26 @@ class S {
     );
   }
 
+  /// `Import from Supabase`
+  String get importSupabaseLabel {
+    return Intl.message(
+      'Import from Supabase',
+      name: 'importSupabaseLabel',
+      desc: '',
+      args: [],
+    );
+  }
+
+  /// `Restore your data from a backup stored in Supabase.`
+  String get importSupabaseDescription {
+    return Intl.message(
+      'Restore your data from a backup stored in Supabase.',
+      name: 'importSupabaseDescription',
+      desc: '',
+      args: [],
+    );
+  }
+
   /// `Add new Item:`
   String get addItemLabel {
     return Intl.message(

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -112,6 +112,8 @@
   "importAction": "Importieren",
   "exportSupabaseLabel": "Zu Supabase exportieren",
   "exportSupabaseDescription": "Sichere deine Daten als Zip-Datei im Supabase-Speicher.",
+  "importSupabaseLabel": "Von Supabase importieren",
+  "importSupabaseDescription": "Stelle deine Daten aus einem in Supabase gespeicherten Backup wieder her.",
   "addItemLabel": "Neuen Eintrag hinzufügen:",
   "activityLabel": "Aktivität",
   "activityExample": "z. B. Laufen, Radfahren, Yoga ...",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -122,6 +122,8 @@
   "importAction": "Import",
   "exportSupabaseLabel": "Export to Supabase",
   "exportSupabaseDescription": "Backup your data to Supabase storage as a zip file.",
+  "importSupabaseLabel": "Import from Supabase",
+  "importSupabaseDescription": "Restore your data from a backup stored in Supabase.",
   "addItemLabel": "Add new Item:",
   "activityLabel": "Activity",
   "activityExample": "e.g. running, biking, yoga ...",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -122,6 +122,8 @@
   "importAction": "Importer",
   "exportSupabaseLabel": "Exporter vers Supabase",
   "exportSupabaseDescription": "Sauvegardez vos données dans le stockage Supabase sous forme de fichier zip.",
+  "importSupabaseLabel": "Importer depuis Supabase",
+  "importSupabaseDescription": "Restaurez vos données à partir d'une sauvegarde stockée sur Supabase.",
   "addItemLabel": "Ajouter un nouvel élément :",
   "activityLabel": "Activité",
   "activityExample": "ex : course, vélo, yoga...",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -117,6 +117,8 @@
   "importAction": "İçe Aktar",
   "exportSupabaseLabel": "Supabase'e Aktar",
   "exportSupabaseDescription": "Verilerinizi zip dosyası olarak Supabase depolamasına yedekleyin.",
+  "importSupabaseLabel": "Supabase'den İçe Aktar",
+  "importSupabaseDescription": "Verilerinizi Supabase'de saklanan bir yedekten geri yükleyin.",
   "addItemLabel": "Yeni Öğe Ekle:",
   "activityLabel": "Aktivite",
   "activityExample": "ör. koşu, bisiklet, yoga ...",


### PR DESCRIPTION
## Summary
- support importing data from Supabase
- register `ImportDataSupabaseUsecase` and expose new bloc event
- add dialog and settings entry for Supabase import
- localise new strings
- regenerate localisation files

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_686ad55ffe088321b5afc12ec8e2314d