### PR TITLE
Add profile photo picker and remove role selection

### DIFF
--- a/lib/features/profile/presentation/widgets/profile_photo_picker.dart
+++ b/lib/features/profile/presentation/widgets/profile_photo_picker.dart
@@ -1,0 +1,69 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:path/path.dart';
+import 'package:path_provider/path_provider.dart';
+
+class ProfilePhotoPicker extends StatefulWidget {
+  final void Function(String imagePath) onImagePicked;
+  final String? initialImagePath;
+  final double size;
+
+  const ProfilePhotoPicker({
+    super.key,
+    required this.onImagePicked,
+    this.initialImagePath,
+    this.size = 240,
+  });
+
+  @override
+  State<ProfilePhotoPicker> createState() => _ProfilePhotoPickerState();
+}
+
+class _ProfilePhotoPickerState extends State<ProfilePhotoPicker> {
+  final ImagePicker _picker = ImagePicker();
+  String? _imagePath;
+
+  @override
+  void initState() {
+    super.initState();
+    _imagePath = widget.initialImagePath;
+  }
+
+  Future<void> _pickImage() async {
+    final pickedFile = await _picker.pickImage(source: ImageSource.gallery);
+    if (pickedFile != null) {
+      final imageFile = File(pickedFile.path);
+      final appDir = await getApplicationDocumentsDirectory();
+      final now = DateTime.now();
+      final formattedTime =
+          '${now.year}${_twoDigits(now.month)}${_twoDigits(now.day)}_${_twoDigits(now.hour)}${_twoDigits(now.minute)}${_twoDigits(now.second)}';
+      final fileName = 'profile_photo_$formattedTime${extension(pickedFile.path)}';
+      final savedPath = join(appDir.path, fileName);
+
+      final savedImage = await imageFile.copy(savedPath);
+
+      setState(() {
+        _imagePath = savedImage.path;
+      });
+      widget.onImagePicked(savedImage.path);
+    }
+  }
+
+  String _twoDigits(int n) => n.toString().padLeft(2, '0');
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: _pickImage,
+      child: CircleAvatar(
+        radius: widget.size / 2,
+        backgroundImage:
+            _imagePath != null ? FileImage(File(_imagePath!)) : null,
+        child: _imagePath == null
+            ? Icon(Icons.camera_alt, size: widget.size / 3)
+            : null,
+      ),
+    );
+  }
+}

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -13,9 +13,7 @@ import 'package:opennutritracker/features/profile/presentation/widgets/set_goal_
 import 'package:opennutritracker/features/profile/presentation/widgets/set_height_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_pal_category_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_weight_dialog.dart';
-import 'package:opennutritracker/features/profile/presentation/widgets/set_role_dialog.dart';
-import 'package:opennutritracker/features/create_meal/pick_image_screen.dart';
-import 'package:opennutritracker/core/domain/entity/user_role_entity.dart';
+import 'package:opennutritracker/features/profile/presentation/widgets/profile_photo_picker.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 import 'package:opennutritracker/features/auth/auth_safe_sign_out.dart';
 
@@ -67,16 +65,12 @@ class _ProfilePageState extends State<ProfilePage> {
       children: [
         const SizedBox(height: 32.0),
         Center(
-          child: SizedBox(
-            width: 240, // Largeur souhaitée
-            height: 240, // Hauteur souhaitée
-            child: PhotoPickerButton(
-              initialImagePath: user.profileImagePath,
-              onImagePicked: (path) {
-                user.profileImagePath = path;
-                _profileBloc.updateUser(user);
-              },
-            ),
+          child: ProfilePhotoPicker(
+            initialImagePath: user.profileImagePath,
+            onImagePicked: (path) {
+              user.profileImagePath = path;
+              _profileBloc.updateUser(user);
+            },
           ),
         ),
         const SizedBox(height: 32.0),
@@ -179,21 +173,6 @@ class _ProfilePageState extends State<ProfilePage> {
           },
         ),
         ListTile(
-          title: Text(
-            S.of(context).roleLabel,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          subtitle: Text(
-            user.role.getName(context),
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: SizedBox(
-            height: double.infinity,
-            child: Icon(user.role.getIcon()),
-          ),
-          onTap: () => _showSetRoleDialog(context, user),
-        ),
-        ListTile(
           leading: const SizedBox(
             height: double.infinity,
             child: Icon(Icons.logout),
@@ -293,14 +272,4 @@ class _ProfilePageState extends State<ProfilePage> {
     }
   }
 
-  Future<void> _showSetRoleDialog(
-      BuildContext context, UserEntity userEntity) async {
-    final selectedRole = await showDialog<UserRoleEntity>(
-        context: context,
-        builder: (BuildContext context) => const SetRoleDialog());
-    if (selectedRole != null) {
-      userEntity.role = selectedRole;
-      _profileBloc.updateUser(userEntity);
-    }
-  }
 }


### PR DESCRIPTION
## Summary
- add `ProfilePhotoPicker` widget to show a circular, larger profile image
- use new profile photo picker on the profile page
- remove the ability to change user role

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68741b7c0ca48321b20cfafffbd5f934