### PR TITLE
Add profile photo picker and remove role selection

### DIFF
--- a/lib/core/data/data_source/user_data_source.dart
+++ b/lib/core/data/data_source/user_data_source.dart
@@ -24,6 +24,7 @@ class UserDataSource {
   Future<UserDBO> getUserData() async {
     return _hive.userBox.get(_userKey) ??
         UserDBO(
+            name: 'John Doe',
             birthday: DateTime(2000, 1, 1),
             heightCM: 180,
             weightKG: 80,

--- a/lib/core/data/dbo/user_dbo.dart
+++ b/lib/core/data/dbo/user_dbo.dart
@@ -25,9 +25,12 @@ class UserDBO extends HiveObject {
   UserRoleDBO role;
   @HiveField(7)
   String? profileImagePath;
+  @HiveField(8)
+  String name;
 
   UserDBO(
-      {required this.birthday,
+      {required this.name,
+      required this.birthday,
       required this.heightCM,
       required this.weightKG,
       required this.gender,
@@ -38,6 +41,7 @@ class UserDBO extends HiveObject {
 
   factory UserDBO.fromUserEntity(UserEntity entity) {
     return UserDBO(
+        name: entity.name,
         birthday: entity.birthday,
         heightCM: entity.heightCM,
         weightKG: entity.weightKG,

--- a/lib/core/data/dbo/user_dbo.g.dart
+++ b/lib/core/data/dbo/user_dbo.g.dart
@@ -25,13 +25,14 @@ class UserDBOAdapter extends TypeAdapter<UserDBO> {
       pal: fields[5] as UserPALDBO,
       role: fields[6] as UserRoleDBO,
       profileImagePath: fields[7] as String?,
+      name: fields[8] as String,
     );
   }
 
   @override
   void write(BinaryWriter writer, UserDBO obj) {
     writer
-      ..writeByte(8)
+      ..writeByte(9)
       ..writeByte(0)
       ..write(obj.birthday)
       ..writeByte(1)
@@ -47,7 +48,9 @@ class UserDBOAdapter extends TypeAdapter<UserDBO> {
       ..writeByte(6)
       ..write(obj.role)
       ..writeByte(7)
-      ..write(obj.profileImagePath);
+      ..write(obj.profileImagePath)
+      ..writeByte(8)
+      ..write(obj.name);
   }
 
   @override

--- a/lib/core/domain/entity/user_entity.dart
+++ b/lib/core/domain/entity/user_entity.dart
@@ -26,6 +26,28 @@ class UserEntity {
       required this.role,
       this.profileImagePath});
 
+  UserEntity copyWith({
+    DateTime? birthday,
+    double? heightCM,
+    double? weightKG,
+    UserGenderEntity? gender,
+    UserWeightGoalEntity? goal,
+    UserPALEntity? pal,
+    UserRoleEntity? role,
+    String? profileImagePath,
+  }) {
+    return UserEntity(
+      birthday: birthday ?? this.birthday,
+      heightCM: heightCM ?? this.heightCM,
+      weightKG: weightKG ?? this.weightKG,
+      gender: gender ?? this.gender,
+      goal: goal ?? this.goal,
+      pal: pal ?? this.pal,
+      role: role ?? this.role,
+      profileImagePath: profileImagePath ?? this.profileImagePath,
+    );
+  }
+
   factory UserEntity.fromUserDBO(UserDBO userDBO) {
     return UserEntity(
         name: userDBO.name,
@@ -39,5 +61,5 @@ class UserEntity {
         profileImagePath: userDBO.profileImagePath);
   }
 
-  int get age => DateTime.now().difference(birthday).inDays~/365;
+  int get age => DateTime.now().difference(birthday).inDays ~/ 365;
 }

--- a/lib/core/domain/entity/user_entity.dart
+++ b/lib/core/domain/entity/user_entity.dart
@@ -5,6 +5,7 @@ import 'package:opennutritracker/core/domain/entity/user_weight_goal_entity.dart
 import 'package:opennutritracker/core/domain/entity/user_role_entity.dart';
 
 class UserEntity {
+  String name;
   DateTime birthday;
   double heightCM;
   double weightKG;
@@ -15,7 +16,8 @@ class UserEntity {
   String? profileImagePath;
 
   UserEntity(
-      {required this.birthday,
+      {required this.name,
+      required this.birthday,
       required this.heightCM,
       required this.weightKG,
       required this.gender,
@@ -26,6 +28,7 @@ class UserEntity {
 
   factory UserEntity.fromUserDBO(UserDBO userDBO) {
     return UserEntity(
+        name: userDBO.name,
         birthday: userDBO.birthday,
         heightCM: userDBO.heightCM,
         weightKG: userDBO.weightKG,

--- a/lib/core/domain/entity/user_entity.dart
+++ b/lib/core/domain/entity/user_entity.dart
@@ -27,6 +27,7 @@ class UserEntity {
       this.profileImagePath});
 
   UserEntity copyWith({
+    String? name,
     DateTime? birthday,
     double? heightCM,
     double? weightKG,
@@ -37,6 +38,7 @@ class UserEntity {
     String? profileImagePath,
   }) {
     return UserEntity(
+      name: name ?? this.name,
       birthday: birthday ?? this.birthday,
       heightCM: heightCM ?? this.heightCM,
       weightKG: weightKG ?? this.weightKG,

--- a/lib/features/profile/presentation/widgets/profile_photo_picker.dart
+++ b/lib/features/profile/presentation/widgets/profile_photo_picker.dart
@@ -1,0 +1,76 @@
+import 'dart:io';
+import 'package:flutter/material.dart';
+import 'package:image_picker/image_picker.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+
+class ProfilePhotoPicker extends StatefulWidget {
+  final void Function(String imagePath) onImagePicked;
+  final String? initialImagePath;
+  final double size;
+
+  const ProfilePhotoPicker({
+    super.key,
+    required this.onImagePicked,
+    this.initialImagePath,
+    this.size = 240,
+  });
+
+  @override
+  State<ProfilePhotoPicker> createState() => _ProfilePhotoPickerState();
+}
+
+class _ProfilePhotoPickerState extends State<ProfilePhotoPicker> {
+  final ImagePicker _picker = ImagePicker();
+  String? _imagePath;
+
+  @override
+  void initState() {
+    super.initState();
+    _imagePath = widget.initialImagePath;
+  }
+
+  Future<void> _pickImage() async {
+    try {
+      final pickedFile = await _picker.pickImage(source: ImageSource.gallery);
+      if (pickedFile != null) {
+        final imageFile = File(pickedFile.path);
+        final appDir = await getApplicationDocumentsDirectory();
+        final now = DateTime.now();
+        final formattedTime =
+            '${now.year}${_twoDigits(now.month)}${_twoDigits(now.day)}_${_twoDigits(now.hour)}${_twoDigits(now.minute)}${_twoDigits(now.second)}';
+        final fileName =
+            'profile_photo_$formattedTime${p.extension(pickedFile.path)}';
+        final savedPath = p.join(appDir.path, fileName);
+
+        final savedImage = await imageFile.copy(savedPath);
+
+        if (!mounted) return;
+        setState(() {
+          _imagePath = savedImage.path;
+        });
+        widget.onImagePicked(savedImage.path);
+      }
+    } catch (e) {
+      debugPrint('Failed to pick and save image: $e');
+    }
+  }
+
+  String _twoDigits(int n) => n.toString().padLeft(2, '0');
+
+  @override
+  Widget build(BuildContext context) {
+    return InkWell(
+      onTap: _pickImage,
+      child: CircleAvatar(
+        radius: widget.size / 2,
+        backgroundImage: _imagePath != null
+            ? FileImage(File(_imagePath!))
+            : null,
+        child: _imagePath == null
+            ? Icon(Icons.camera_alt, size: widget.size / 3)
+            : null,
+      ),
+    );
+  }
+}

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -5,6 +5,7 @@ import 'package:opennutritracker/core/domain/entity/user_entity.dart';
 import 'package:opennutritracker/core/domain/entity/user_gender_entity.dart';
 import 'package:opennutritracker/core/domain/entity/user_pal_entity.dart';
 import 'package:opennutritracker/core/domain/entity/user_weight_goal_entity.dart';
+import 'package:opennutritracker/core/domain/entity/user_role_entity.dart';
 import 'package:opennutritracker/core/utils/calc/unit_calc.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/features/profile/presentation/bloc/profile_bloc.dart';
@@ -13,9 +14,7 @@ import 'package:opennutritracker/features/profile/presentation/widgets/set_goal_
 import 'package:opennutritracker/features/profile/presentation/widgets/set_height_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_pal_category_dialog.dart';
 import 'package:opennutritracker/features/profile/presentation/widgets/set_weight_dialog.dart';
-import 'package:opennutritracker/features/profile/presentation/widgets/set_role_dialog.dart';
-import 'package:opennutritracker/features/create_meal/pick_image_screen.dart';
-import 'package:opennutritracker/core/domain/entity/user_role_entity.dart';
+import 'package:opennutritracker/features/profile/presentation/widgets/profile_photo_picker.dart';
 import 'package:opennutritracker/generated/l10n.dart';
 import 'package:opennutritracker/features/auth/auth_safe_sign_out.dart';
 
@@ -63,24 +62,39 @@ class _ProfilePageState extends State<ProfilePage> {
 
   Widget _getLoadedContent(BuildContext context, UserBMIEntity bmiEntity,
       UserEntity user, bool usesImperialUnits) {
+    final isCoach = user.role == UserRoleEntity.coach;
     return ListView(
       children: [
         const SizedBox(height: 32.0),
         Center(
-          child: SizedBox(
-            width: 240, // Largeur souhaitée
-            height: 240, // Hauteur souhaitée
-            child: PhotoPickerButton(
-              initialImagePath: user.profileImagePath,
-              onImagePicked: (path) {
-                user.profileImagePath = path;
-                _profileBloc.updateUser(user);
-              },
-            ),
+          child: Column(
+            children: [
+              ProfilePhotoPicker(
+                initialImagePath: user.profileImagePath,
+                onImagePicked: (path) {
+                  final updatedUser = UserEntity(
+                    name: user.name,
+                    birthday: user.birthday,
+                    heightCM: user.heightCM,
+                    weightKG: user.weightKG,
+                    gender: user.gender,
+                    goal: user.goal,
+                    pal: user.pal,
+                    role: user.role,
+                    profileImagePath: path,
+                  );
+                  _profileBloc.updateUser(updatedUser);
+                },
+              ),
+              const SizedBox(height: 16.0),
+              Text(user.name,
+                  style: Theme.of(context).textTheme.titleLarge),
+            ],
           ),
         ),
         const SizedBox(height: 32.0),
-        ListTile(
+        if (!isCoach)
+          ListTile(
           title: Text(
             S.of(context).activityLabel,
             style: Theme.of(context).textTheme.titleLarge,
@@ -95,7 +109,8 @@ class _ProfilePageState extends State<ProfilePage> {
           ),
           onTap: () => _showSetPALCategoryDialog(context, user),
         ),
-        ListTile(
+        if (!isCoach)
+          ListTile(
           title: Text(
             S.of(context).goalLabel,
             style: Theme.of(context).textTheme.titleLarge,
@@ -110,7 +125,8 @@ class _ProfilePageState extends State<ProfilePage> {
           ),
           onTap: () => _showSetGoalDialog(context, user),
         ),
-        ListTile(
+        if (!isCoach)
+          ListTile(
           title: Text(
             S.of(context).weightLabel,
             style: Theme.of(context).textTheme.titleLarge,
@@ -127,7 +143,8 @@ class _ProfilePageState extends State<ProfilePage> {
             _showSetWeightDialog(context, user, usesImperialUnits);
           },
         ),
-        ListTile(
+        if (!isCoach)
+          ListTile(
           title: Text(
             S.of(context).heightLabel,
             style: Theme.of(context).textTheme.titleLarge,
@@ -144,7 +161,8 @@ class _ProfilePageState extends State<ProfilePage> {
             _showSetHeightDialog(context, user, usesImperialUnits);
           },
         ),
-        ListTile(
+        if (!isCoach)
+          ListTile(
           title: Text(
             S.of(context).ageLabel,
             style: Theme.of(context).textTheme.titleLarge,
@@ -161,7 +179,8 @@ class _ProfilePageState extends State<ProfilePage> {
             _showSetBirthdayDialog(context, user);
           },
         ),
-        ListTile(
+        if (!isCoach)
+          ListTile(
           title: Text(
             S.of(context).genderLabel,
             style: Theme.of(context).textTheme.titleLarge,
@@ -177,21 +196,6 @@ class _ProfilePageState extends State<ProfilePage> {
           onTap: () {
             _showSetGenderDialog(context, user);
           },
-        ),
-        ListTile(
-          title: Text(
-            S.of(context).roleLabel,
-            style: Theme.of(context).textTheme.titleLarge,
-          ),
-          subtitle: Text(
-            user.role.getName(context),
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: SizedBox(
-            height: double.infinity,
-            child: Icon(user.role.getIcon()),
-          ),
-          onTap: () => _showSetRoleDialog(context, user),
         ),
         ListTile(
           leading: const SizedBox(
@@ -293,14 +297,4 @@ class _ProfilePageState extends State<ProfilePage> {
     }
   }
 
-  Future<void> _showSetRoleDialog(
-      BuildContext context, UserEntity userEntity) async {
-    final selectedRole = await showDialog<UserRoleEntity>(
-        context: context,
-        builder: (BuildContext context) => const SetRoleDialog());
-    if (selectedRole != null) {
-      userEntity.role = selectedRole;
-      _profileBloc.updateUser(userEntity);
-    }
-  }
 }

--- a/lib/features/profile/profile_page.dart
+++ b/lib/features/profile/profile_page.dart
@@ -72,131 +72,120 @@ class _ProfilePageState extends State<ProfilePage> {
               ProfilePhotoPicker(
                 initialImagePath: user.profileImagePath,
                 onImagePicked: (path) {
-                  final updatedUser = UserEntity(
-                    name: user.name,
-                    birthday: user.birthday,
-                    heightCM: user.heightCM,
-                    weightKG: user.weightKG,
-                    gender: user.gender,
-                    goal: user.goal,
-                    pal: user.pal,
-                    role: user.role,
-                    profileImagePath: path,
-                  );
+                  final updatedUser = user.copyWith(profileImagePath: path);
                   _profileBloc.updateUser(updatedUser);
                 },
               ),
               const SizedBox(height: 16.0),
-              Text(user.name,
-                  style: Theme.of(context).textTheme.titleLarge),
+              Text(user.name, style: Theme.of(context).textTheme.titleLarge),
             ],
           ),
         ),
         const SizedBox(height: 32.0),
         if (!isCoach)
           ListTile(
-          title: Text(
-            S.of(context).activityLabel,
-            style: Theme.of(context).textTheme.titleLarge,
+            title: Text(
+              S.of(context).activityLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              user.pal.getName(context),
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: const SizedBox(
+              height: double.infinity,
+              child: Icon(Icons.directions_walk_outlined),
+            ),
+            onTap: () => _showSetPALCategoryDialog(context, user),
           ),
-          subtitle: Text(
-            user.pal.getName(context),
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: const SizedBox(
-            height: double.infinity,
-            child: Icon(Icons.directions_walk_outlined),
-          ),
-          onTap: () => _showSetPALCategoryDialog(context, user),
-        ),
         if (!isCoach)
           ListTile(
-          title: Text(
-            S.of(context).goalLabel,
-            style: Theme.of(context).textTheme.titleLarge,
+            title: Text(
+              S.of(context).goalLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              user.goal.getName(context),
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: const SizedBox(
+              height: double.infinity,
+              child: Icon(Icons.flag_outlined),
+            ),
+            onTap: () => _showSetGoalDialog(context, user),
           ),
-          subtitle: Text(
-            user.goal.getName(context),
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: const SizedBox(
-            height: double.infinity,
-            child: Icon(Icons.flag_outlined),
-          ),
-          onTap: () => _showSetGoalDialog(context, user),
-        ),
         if (!isCoach)
           ListTile(
-          title: Text(
-            S.of(context).weightLabel,
-            style: Theme.of(context).textTheme.titleLarge,
+            title: Text(
+              S.of(context).weightLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              '${_profileBloc.getDisplayWeight(user, usesImperialUnits)} ${usesImperialUnits ? S.of(context).lbsLabel : S.of(context).kgLabel}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: const SizedBox(
+              height: double.infinity,
+              child: Icon(Icons.monitor_weight_outlined),
+            ),
+            onTap: () {
+              _showSetWeightDialog(context, user, usesImperialUnits);
+            },
           ),
-          subtitle: Text(
-            '${_profileBloc.getDisplayWeight(user, usesImperialUnits)} ${usesImperialUnits ? S.of(context).lbsLabel : S.of(context).kgLabel}',
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: const SizedBox(
-            height: double.infinity,
-            child: Icon(Icons.monitor_weight_outlined),
-          ),
-          onTap: () {
-            _showSetWeightDialog(context, user, usesImperialUnits);
-          },
-        ),
         if (!isCoach)
           ListTile(
-          title: Text(
-            S.of(context).heightLabel,
-            style: Theme.of(context).textTheme.titleLarge,
+            title: Text(
+              S.of(context).heightLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              '${_profileBloc.getDisplayHeight(user, usesImperialUnits)} ${usesImperialUnits ? S.of(context).ftLabel : S.of(context).cmLabel}',
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: const SizedBox(
+              height: double.infinity,
+              child: Icon(Icons.height_outlined),
+            ),
+            onTap: () {
+              _showSetHeightDialog(context, user, usesImperialUnits);
+            },
           ),
-          subtitle: Text(
-            '${_profileBloc.getDisplayHeight(user, usesImperialUnits)} ${usesImperialUnits ? S.of(context).ftLabel : S.of(context).cmLabel}',
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: const SizedBox(
-            height: double.infinity,
-            child: Icon(Icons.height_outlined),
-          ),
-          onTap: () {
-            _showSetHeightDialog(context, user, usesImperialUnits);
-          },
-        ),
         if (!isCoach)
           ListTile(
-          title: Text(
-            S.of(context).ageLabel,
-            style: Theme.of(context).textTheme.titleLarge,
+            title: Text(
+              S.of(context).ageLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              S.of(context).yearsLabel(user.age),
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: const SizedBox(
+              height: double.infinity,
+              child: Icon(Icons.cake_outlined),
+            ),
+            onTap: () {
+              _showSetBirthdayDialog(context, user);
+            },
           ),
-          subtitle: Text(
-            S.of(context).yearsLabel(user.age),
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: const SizedBox(
-            height: double.infinity,
-            child: Icon(Icons.cake_outlined),
-          ),
-          onTap: () {
-            _showSetBirthdayDialog(context, user);
-          },
-        ),
         if (!isCoach)
           ListTile(
-          title: Text(
-            S.of(context).genderLabel,
-            style: Theme.of(context).textTheme.titleLarge,
+            title: Text(
+              S.of(context).genderLabel,
+              style: Theme.of(context).textTheme.titleLarge,
+            ),
+            subtitle: Text(
+              user.gender.getName(context),
+              style: Theme.of(context).textTheme.titleMedium,
+            ),
+            leading: SizedBox(
+              height: double.infinity,
+              child: Icon(user.gender.getIcon()),
+            ),
+            onTap: () {
+              _showSetGenderDialog(context, user);
+            },
           ),
-          subtitle: Text(
-            user.gender.getName(context),
-            style: Theme.of(context).textTheme.titleMedium,
-          ),
-          leading: SizedBox(
-            height: double.infinity,
-            child: Icon(user.gender.getIcon()),
-          ),
-          onTap: () {
-            _showSetGenderDialog(context, user);
-          },
-        ),
         ListTile(
           leading: const SizedBox(
             height: double.infinity,
@@ -296,5 +285,4 @@ class _ProfilePageState extends State<ProfilePage> {
       _profileBloc.updateUser(userEntity);
     }
   }
-
 }

--- a/test/fixture/user_entity_fixtures.dart
+++ b/test/fixture/user_entity_fixtures.dart
@@ -8,6 +8,7 @@ class UserEntityFixtures {
   /// Mocked user entity
   /// 25 years, 180 cm, 80 kg, male, maintain weight, sedentary
   static final youngSedentaryMaleWantingToMaintainWeight = UserEntity(
+      name: 'Young Male',
       birthday: DateTime(DateTime.now().year - 25, DateTime.now().month,
           DateTime.now().day - 1),
       heightCM: 180.0,
@@ -20,6 +21,7 @@ class UserEntityFixtures {
   /// Mocked user entity
   /// 54 years, 160 cm, 75 kg, female, lose weight, active
   static final UserEntity middleAgedActiveFemaleWantingToLoseWeight = UserEntity(
+      name: 'Middle Aged Female',
       birthday: DateTime(DateTime.now().year - 54, DateTime.now().month,
           DateTime.now().day - 1),
       heightCM: 160.0,
@@ -32,6 +34,7 @@ class UserEntityFixtures {
   /// Mocked user entity
   /// 76 years, 164 cm, 55 kg, male, gain weight, low active
   static final UserEntity elderlyLowActiveMaleWantingToGainWeight = UserEntity(
+    name: 'Elderly Male',
     birthday: DateTime(
         DateTime.now().year - 76, DateTime.now().month, DateTime.now().day - 1),
     heightCM: 164.0,
@@ -46,6 +49,7 @@ class UserEntityFixtures {
   /// 19 years, 190 cm, 105 kg, female, lose weight, very active
   static final UserEntity youngVeryActiveOverweightFemaleWantingToLoseWeight =
       UserEntity(
+    name: 'Young Female',
     birthday: DateTime(
         DateTime.now().year - 19, DateTime.now().month, DateTime.now().day - 1),
     heightCM: 190.0,

--- a/test/unit_test/tdee_calc_test.dart
+++ b/test/unit_test/tdee_calc_test.dart
@@ -12,6 +12,7 @@ void main() {
   test('IOM TDEE calculation for a male user', () {
     // Mock a male user
     UserEntity user = UserEntity(
+        name: 'John',
         birthday: DateTime(DateTime.now().year - 25, DateTime.now().month,
             DateTime.now().day - 1),
         heightCM: 180.0,


### PR DESCRIPTION
## Summary
- add ProfilePhotoPicker widget to show a circular, larger profile image
- use new profile photo picker on the profile page
- remove the ability to change user role
- update profile photo with immutable user updates
- handle errors in `_pickImage` and check for `mounted`
- show the user name below the profile picture
- hide weight/height/age/gender details when the user is a coach
- fix linter warning by aliasing `path` import and using `mounted` check

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_68741b7c0ca48321b20cfafffbd5f934