### PR TITLE
Add photo backup to Supabase sync

### DIFF
--- a/lib/core/data/dbo/meal_dbo.dart
+++ b/lib/core/data/dbo/meal_dbo.dart
@@ -2,6 +2,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:path/path.dart' as p;
 
 part 'meal_dbo.g.dart';
 
@@ -61,9 +62,17 @@ class MealDBO extends HiveObject {
       code: mealEntity.code,
       name: mealEntity.name,
       brands: mealEntity.brands,
-      thumbnailImageUrl: mealEntity.thumbnailImageUrl,
-      mainImageUrl: mealEntity.mainImageUrl,
-      url: mealEntity.url,
+      thumbnailImageUrl: mealEntity.thumbnailImageUrl != null &&
+              !mealEntity.thumbnailImageUrl!.startsWith('http')
+          ? p.basename(mealEntity.thumbnailImageUrl!)
+          : mealEntity.thumbnailImageUrl,
+      mainImageUrl: mealEntity.mainImageUrl != null &&
+              !mealEntity.mainImageUrl!.startsWith('http')
+          ? p.basename(mealEntity.mainImageUrl!)
+          : mealEntity.mainImageUrl,
+      url: mealEntity.url != null && !mealEntity.url!.startsWith('http')
+          ? p.basename(mealEntity.url!)
+          : mealEntity.url,
       mealQuantity: mealEntity.mealQuantity,
       mealUnit: mealEntity.mealUnit,
       servingQuantity: mealEntity.servingQuantity,

--- a/lib/core/data/dbo/user_dbo.dart
+++ b/lib/core/data/dbo/user_dbo.dart
@@ -3,6 +3,7 @@ import 'package:opennutritracker/core/data/dbo/user_gender_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_pal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_weight_goal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_role_dbo.dart';
+import 'package:path/path.dart' as p;
 import 'package:opennutritracker/core/domain/entity/user_entity.dart';
 
 part 'user_dbo.g.dart';
@@ -49,6 +50,8 @@ class UserDBO extends HiveObject {
         goal: UserWeightGoalDBO.fromUserWeightGoalEntity(entity.goal),
         pal: UserPALDBO.fromUserPALEntity(entity.pal),
         role: UserRoleDBO.fromUserRoleEntity(entity.role),
-        profileImagePath: entity.profileImagePath);
+        profileImagePath: entity.profileImagePath != null
+            ? p.basename(entity.profileImagePath!)
+            : null);
   }
 }

--- a/lib/core/data/repository/recipe_repository.dart
+++ b/lib/core/data/repository/recipe_repository.dart
@@ -36,6 +36,16 @@ class RecipeRepository {
     return list.map((r) => r.toEntity()).toList();
   }
 
+  /// Récupérer toutes les recettes au format DBO
+  Future<List<RecipesDBO>> getAllRecipeDBOs() async {
+    return await _dataSource.getAllRecipes();
+  }
+
+  /// Ajouter plusieurs recettes en DBO
+  Future<void> addAllRecipeDBOs(List<RecipesDBO> recipes) async {
+    await _dataSource.addAllRecipes(recipes);
+  }
+
   /// Rechercher des recettes par texte
   Future<List<RecipeEntity>> searchRecipes(String query) async {
     final results = await _dataSource.searchRecipes(query);

--- a/lib/core/domain/usecase/delete_recipe_usecase.dart
+++ b/lib/core/domain/usecase/delete_recipe_usecase.dart
@@ -1,5 +1,6 @@
 import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
 import 'dart:io';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 
 class DeleteRecipeUsecase {
   final RecipeRepository _recipeRepository;
@@ -17,7 +18,7 @@ class DeleteRecipeUsecase {
       ];
       for (final path in paths) {
         if (path != null && !path.startsWith('http')) {
-          final file = File(path);
+          final file = File(await PathHelper.localImagePath(path));
           if (await file.exists()) {
             try {
               await file.delete();

--- a/lib/core/presentation/widgets/image_full_screen.dart
+++ b/lib/core/presentation/widgets/image_full_screen.dart
@@ -4,6 +4,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_placeholder.dart';
 
 class ImageFullScreen extends StatefulWidget {
@@ -51,13 +52,22 @@ class _ImageFullScreenState extends State<ImageFullScreen> {
                   placeholder: (context, string) => const MealPlaceholder(),
                   errorWidget: (context, url, error) => const MealPlaceholder(),
                 )
-              : Image.file(
-                  File(imageUrl),
-                  width: double.infinity,
-                  height: double.infinity,
-                  fit: BoxFit.cover,
-                  errorBuilder: (context, error, stackTrace) =>
-                      const MealPlaceholder(),
+              : FutureBuilder<String>(
+                  future: PathHelper.localImagePath(imageUrl),
+                  builder: (context, snapshot) {
+                    final path = snapshot.data;
+                    if (path == null) {
+                      return const SizedBox.shrink();
+                    }
+                    return Image.file(
+                      File(path),
+                      width: double.infinity,
+                      height: double.infinity,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) =>
+                          const MealPlaceholder(),
+                    );
+                  },
                 ),
         ),
       ),

--- a/lib/core/presentation/widgets/intake_card.dart
+++ b/lib/core/presentation/widgets/intake_card.dart
@@ -6,6 +6,7 @@ import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/core/presentation/widgets/meal_value_unit_text.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 import 'dart:io';
 
 class IntakeCard extends StatelessWidget {
@@ -49,14 +50,23 @@ class IntakeCard extends StatelessWidget {
                 children: [
                   intake.meal.mainImageUrl != null
                       ? intake.meal.mealOrRecipe == MealOrRecipeEntity.recipe
-                          ? Container(
-                              decoration: BoxDecoration(
-                                image: DecorationImage(
-                                  image: FileImage(
-                                      File(intake.meal.mainImageUrl!)),
-                                  fit: BoxFit.cover,
-                                ),
-                              ),
+                          ? FutureBuilder<String>(
+                              future: PathHelper.localImagePath(
+                                  intake.meal.mainImageUrl!),
+                              builder: (context, snapshot) {
+                                final path = snapshot.data;
+                                if (path == null) {
+                                  return const SizedBox.shrink();
+                                }
+                                return Container(
+                                  decoration: BoxDecoration(
+                                    image: DecorationImage(
+                                      image: FileImage(File(path)),
+                                      fit: BoxFit.cover,
+                                    ),
+                                  ),
+                                );
+                              },
                             )
                           : CachedNetworkImage(
                               cacheManager: locator<CacheManager>(),

--- a/lib/core/utils/locator.dart
+++ b/lib/core/utils/locator.dart
@@ -206,13 +206,29 @@ Future<void> registerUserScope(HiveDBProvider hive) async {
   );
   locator.registerLazySingleton(() => GetMacroGoalUsecase(locator()));
   locator.registerLazySingleton(
-    () => ExportDataUsecase(locator(), locator(), locator(), locator()),
+    () => ExportDataUsecase(
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+    ),
   );
   locator.registerLazySingleton(
-    () => ImportDataUsecase(locator(), locator(), locator(), locator()),
+    () => ImportDataUsecase(
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+      locator(),
+    ),
   );
   locator.registerLazySingleton(
     () => ExportDataSupabaseUsecase(
+      locator(),
+      locator(),
       locator(),
       locator(),
       locator(),
@@ -222,6 +238,8 @@ Future<void> registerUserScope(HiveDBProvider hive) async {
   );
   locator.registerLazySingleton(
     () => ImportDataSupabaseUsecase(
+      locator(),
+      locator(),
       locator(),
       locator(),
       locator(),

--- a/lib/core/utils/path_helper.dart
+++ b/lib/core/utils/path_helper.dart
@@ -1,0 +1,14 @@
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+import 'dart:io';
+
+class PathHelper {
+  static Directory? _overrideDir;
+
+  static set overrideDirectory(Directory? dir) => _overrideDir = dir;
+
+  static Future<String> localImagePath(String fileName) async {
+    final dir = _overrideDir ?? await getApplicationDocumentsDirectory();
+    return p.join(dir.path, fileName);
+  }
+}

--- a/lib/features/add_meal/presentation/widgets/meal_item_card.dart
+++ b/lib/features/add_meal/presentation/widgets/meal_item_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:opennutritracker/core/presentation/widgets/meal_value_unit_text.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.dart';
@@ -41,11 +42,21 @@ class MealItemCard extends StatelessWidget {
                     mealEntity.thumbnailImageUrl != null
                 ? ClipRRect(
                     borderRadius: BorderRadius.circular(16),
-                    child: Image.file(
-                      File(mealEntity.thumbnailImageUrl!),
-                      width: 60,
-                      height: 60,
-                      fit: BoxFit.cover,
+                    child: FutureBuilder<String>(
+                      future: PathHelper.localImagePath(
+                          mealEntity.thumbnailImageUrl!),
+                      builder: (context, snapshot) {
+                        final path = snapshot.data;
+                        if (path == null) {
+                          return const SizedBox(width: 60, height: 60);
+                        }
+                        return Image.file(
+                          File(path),
+                          width: 60,
+                          height: 60,
+                          fit: BoxFit.cover,
+                        );
+                      },
                     ),
                   )
                 : mealEntity.thumbnailImageUrl != null

--- a/lib/features/auth/auth_safe_sign_out.dart
+++ b/lib/features/auth/auth_safe_sign_out.dart
@@ -70,6 +70,8 @@ Future<void> safeSignOut(BuildContext context) async {
               ExportImportBloc.userIntakeJsonFileName,
               ExportImportBloc.trackedDayJsonFileName,
               ExportImportBloc.userWeightJsonFileName,
+              ExportImportBloc.recipesJsonFileName,
+              ExportImportBloc.userJsonFileName,
             );
 
         var ok = await doExport();

--- a/lib/features/auth/login_screen.dart
+++ b/lib/features/auth/login_screen.dart
@@ -93,6 +93,8 @@ class _LoginScreenState extends State<LoginScreen> {
           ExportImportBloc.userIntakeJsonFileName,
           ExportImportBloc.trackedDayJsonFileName,
           ExportImportBloc.userWeightJsonFileName,
+          ExportImportBloc.recipesJsonFileName,
+          ExportImportBloc.userJsonFileName,
         );
 
         // ── 3. ERREUR D’IMPORT  →  on déconnecte la session

--- a/lib/features/meal_detail/meal_detail_screen.dart
+++ b/lib/features/meal_detail/meal_detail_screen.dart
@@ -18,6 +18,7 @@ import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_detail_nutriments_table.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_info_button.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_placeholder.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_title_expanded.dart';
 import 'package:opennutritracker/core/domain/usecase/get_recipe_usecase.dart';
 import 'package:opennutritracker/generated/l10n.dart';
@@ -237,16 +238,26 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
                       ? meal.mealOrRecipe == MealOrRecipeEntity.recipe
                           ? Hero(
                               tag: ImageFullScreen.fullScreenHeroTag,
-                              child: Container(
-                                width: 250,
-                                height: 250,
-                                decoration: BoxDecoration(
-                                  borderRadius: BorderRadius.circular(8),
-                                  image: DecorationImage(
-                                    image: FileImage(File(meal.mainImageUrl!)),
-                                    fit: BoxFit.cover,
-                                  ),
-                                ),
+                              child: FutureBuilder<String>(
+                                future: PathHelper.localImagePath(
+                                    meal.mainImageUrl!),
+                                builder: (context, snapshot) {
+                                  final path = snapshot.data;
+                                  if (path == null) {
+                                    return const SizedBox.shrink();
+                                  }
+                                  return Container(
+                                    width: 250,
+                                    height: 250,
+                                    decoration: BoxDecoration(
+                                      borderRadius: BorderRadius.circular(8),
+                                      image: DecorationImage(
+                                        image: FileImage(File(path)),
+                                        fit: BoxFit.cover,
+                                      ),
+                                    ),
+                                  );
+                                },
                               ),
                             )
                           : Hero(

--- a/lib/features/settings/domain/usecase/export_data_supabase_usecase.dart
+++ b/lib/features/settings/domain/usecase/export_data_supabase_usecase.dart
@@ -12,6 +12,7 @@ import 'package:opennutritracker/core/data/repository/user_repository.dart';
 import 'package:path/path.dart' as p;
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:logging/logging.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 
 /// Exports user data to a zip file and uploads it to Supabase storage.
 class ExportDataSupabaseUsecase {
@@ -126,7 +127,7 @@ class ExportDataSupabaseUsecase {
     }
 
     for (final path in imagePaths) {
-      final file = File(path);
+      final file = File(await PathHelper.localImagePath(path));
       if (await file.exists()) {
         final bytes = await file.readAsBytes();
         final filename = p.basename(path);

--- a/lib/features/settings/domain/usecase/export_data_supabase_usecase.dart
+++ b/lib/features/settings/domain/usecase/export_data_supabase_usecase.dart
@@ -1,11 +1,15 @@
 import 'dart:convert';
 import 'dart:typed_data';
+import 'dart:io';
 
 import 'package:archive/archive_io.dart';
 import 'package:opennutritracker/core/data/repository/intake_repository.dart';
 import 'package:opennutritracker/core/data/repository/tracked_day_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_weight_repository.dart';
+import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_repository.dart';
+import 'package:path/path.dart' as p;
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:logging/logging.dart';
 
@@ -15,11 +19,20 @@ class ExportDataSupabaseUsecase {
   final IntakeRepository _intakeRepository;
   final TrackedDayRepository _trackedDayRepository;
   final UserWeightRepository _userWeightRepository;
+  final RecipeRepository _recipeRepository;
+  final UserRepository _userRepository;
   final SupabaseClient _client;
   final _log = Logger('ExportServiceZipSupabaseUsecase');
 
-  ExportDataSupabaseUsecase(this._userActivityRepository,
-      this._intakeRepository, this._trackedDayRepository, this._userWeightRepository, this._client);
+  ExportDataSupabaseUsecase(
+    this._userActivityRepository,
+    this._intakeRepository,
+    this._trackedDayRepository,
+    this._userWeightRepository,
+    this._recipeRepository,
+    this._userRepository,
+    this._client,
+  );
 
   /// Creates a zipped backup and uploads it to Supabase storage.
   Future<bool> exportData(
@@ -28,6 +41,8 @@ class ExportDataSupabaseUsecase {
     String userIntakeJsonFileName,
     String trackedDayJsonFileName,
     String userWeightJsonFileName,
+    String recipesJsonFileName,
+    String userJsonFileName,
   ) async {
     // Export user activity data to Json File Bytes
     final fullUserActivity =
@@ -54,6 +69,29 @@ class ExportDataSupabaseUsecase {
         jsonEncode(fullUserWeight.map((w) => w.toJson()).toList());
     final userWeightJsonBytes = utf8.encode(fullUserWeightJson);
 
+    // Export recipes data to Json File Bytes
+    final fullRecipes = await _recipeRepository.getAllRecipeDBOs();
+    final fullRecipesJson =
+        jsonEncode(fullRecipes.map((r) => r.toJson()).toList());
+    final recipesJsonBytes = utf8.encode(fullRecipesJson);
+
+    // Export user data to Json File Bytes
+    final userDBO = await _userRepository.getUserDBO();
+    final userMap = {
+      'name': userDBO.name,
+      'birthday': userDBO.birthday.toIso8601String(),
+      'heightCM': userDBO.heightCM,
+      'weightKG': userDBO.weightKG,
+      'gender': userDBO.gender.index,
+      'goal': userDBO.goal.index,
+      'pal': userDBO.pal.index,
+      'role': userDBO.role.index,
+      'profileImagePath': userDBO.profileImagePath != null
+          ? p.basename(userDBO.profileImagePath!)
+          : null,
+    };
+    final userJsonBytes = utf8.encode(jsonEncode(userMap));
+
     // Create a zip file with the exported data
     final archive = Archive()
       ..addFile(ArchiveFile(userActivityJsonFileName,
@@ -63,7 +101,38 @@ class ExportDataSupabaseUsecase {
       ..addFile(ArchiveFile(trackedDayJsonFileName, trackedDayJsonBytes.length,
           trackedDayJsonBytes))
       ..addFile(ArchiveFile(userWeightJsonFileName, userWeightJsonBytes.length,
-          userWeightJsonBytes));
+          userWeightJsonBytes))
+      ..addFile(ArchiveFile(recipesJsonFileName, recipesJsonBytes.length,
+          recipesJsonBytes))
+      ..addFile(ArchiveFile(userJsonFileName, userJsonBytes.length,
+          userJsonBytes));
+
+    final imagePaths = <String>{};
+    if (userDBO.profileImagePath != null &&
+        !userDBO.profileImagePath!.startsWith('http')) {
+      imagePaths.add(userDBO.profileImagePath!);
+    }
+    for (final recipe in fullRecipes) {
+      final paths = [
+        recipe.recipe.url,
+        recipe.recipe.thumbnailImageUrl,
+        recipe.recipe.mainImageUrl,
+      ];
+      for (final path in paths) {
+        if (path != null && path.isNotEmpty && !path.startsWith('http')) {
+          imagePaths.add(path);
+        }
+      }
+    }
+
+    for (final path in imagePaths) {
+      final file = File(path);
+      if (await file.exists()) {
+        final bytes = await file.readAsBytes();
+        final filename = p.basename(path);
+        archive.addFile(ArchiveFile('images/$filename', bytes.length, bytes));
+      }
+    }
 
     final zipBytes = ZipEncoder().encode(archive);
 

--- a/lib/features/settings/domain/usecase/export_data_usecase.dart
+++ b/lib/features/settings/domain/usecase/export_data_usecase.dart
@@ -7,15 +7,21 @@ import 'package:opennutritracker/core/data/repository/intake_repository.dart';
 import 'package:opennutritracker/core/data/repository/tracked_day_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_weight_repository.dart';
+import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_repository.dart';
+import 'package:path/path.dart' as p;
+import 'dart:io';
 
 class ExportDataUsecase {
   final UserActivityRepository _userActivityRepository;
   final IntakeRepository _intakeRepository;
   final TrackedDayRepository _trackedDayRepository;
   final UserWeightRepository _userWeightRepository;
+  final RecipeRepository _recipeRepository;
+  final UserRepository _userRepository;
 
   ExportDataUsecase(this._userActivityRepository, this._intakeRepository,
-      this._trackedDayRepository, this._userWeightRepository);
+      this._trackedDayRepository, this._userWeightRepository, this._recipeRepository, this._userRepository);
 
   /// Exports user activity, intake, and tracked day data to a zip of json
   /// files at a user specified location.
@@ -24,7 +30,9 @@ class ExportDataUsecase {
       String userActivityJsonFileName,
       String userIntakeJsonFileName,
       String trackedDayJsonFileName,
-      String userWeightJsonFileName) async {
+      String userWeightJsonFileName,
+      String recipesJsonFileName,
+      String userJsonFileName) async {
     // Export user activity data to Json File Bytes
     final fullUserActivity =
         await _userActivityRepository.getAllUserActivityDBO();
@@ -50,24 +58,70 @@ class ExportDataUsecase {
         jsonEncode(fullUserWeight.map((w) => w.toJson()).toList());
     final userWeightJsonBytes = utf8.encode(fullUserWeightJson);
 
+    // Export recipes data
+    final fullRecipes = await _recipeRepository.getAllRecipeDBOs();
+    final fullRecipesJson =
+        jsonEncode(fullRecipes.map((r) => r.toJson()).toList());
+    final recipesJsonBytes = utf8.encode(fullRecipesJson);
+
+    // Export user data
+    final userDBO = await _userRepository.getUserDBO();
+    final userMap = {
+      'name': userDBO.name,
+      'birthday': userDBO.birthday.toIso8601String(),
+      'heightCM': userDBO.heightCM,
+      'weightKG': userDBO.weightKG,
+      'gender': userDBO.gender.index,
+      'goal': userDBO.goal.index,
+      'pal': userDBO.pal.index,
+      'role': userDBO.role.index,
+      'profileImagePath': userDBO.profileImagePath != null
+          ? p.basename(userDBO.profileImagePath!)
+          : null,
+    };
+    final userJsonBytes = utf8.encode(jsonEncode(userMap));
+
     // Create a zip file with the exported data
     final archive = Archive();
-    archive.addFile(
-      ArchiveFile(userActivityJsonFileName, userActivityJsonBytes.length,
-          userActivityJsonBytes),
-    );
-    archive.addFile(
-      ArchiveFile(
-          userIntakeJsonFileName, intakeJsonBytes.length, intakeJsonBytes),
-    );
-    archive.addFile(
-      ArchiveFile(trackedDayJsonFileName, trackedDayJsonBytes.length,
-          trackedDayJsonBytes),
-    );
-    archive.addFile(
-      ArchiveFile(userWeightJsonFileName, userWeightJsonBytes.length,
-          userWeightJsonBytes),
-    );
+    archive.addFile(ArchiveFile(userActivityJsonFileName,
+        userActivityJsonBytes.length, userActivityJsonBytes));
+    archive.addFile(ArchiveFile(
+        userIntakeJsonFileName, intakeJsonBytes.length, intakeJsonBytes));
+    archive.addFile(ArchiveFile(trackedDayJsonFileName, trackedDayJsonBytes.length,
+        trackedDayJsonBytes));
+    archive.addFile(ArchiveFile(userWeightJsonFileName, userWeightJsonBytes.length,
+        userWeightJsonBytes));
+    archive.addFile(ArchiveFile(recipesJsonFileName, recipesJsonBytes.length,
+        recipesJsonBytes));
+    archive.addFile(ArchiveFile(userJsonFileName, userJsonBytes.length,
+        userJsonBytes));
+
+    final imagePaths = <String>{};
+    if (userDBO.profileImagePath != null &&
+        userDBO.profileImagePath!.isNotEmpty) {
+      imagePaths.add(userDBO.profileImagePath!);
+    }
+    for (final recipe in fullRecipes) {
+      final paths = [
+        recipe.recipe.url,
+        recipe.recipe.thumbnailImageUrl,
+        recipe.recipe.mainImageUrl,
+      ];
+      for (final path in paths) {
+        if (path != null && path.isNotEmpty && !path.startsWith('http')) {
+          imagePaths.add(path);
+        }
+      }
+    }
+
+    for (final path in imagePaths) {
+      final file = File(path);
+      if (await file.exists()) {
+        final bytes = await file.readAsBytes();
+        final name = p.basename(path);
+        archive.addFile(ArchiveFile('images/$name', bytes.length, bytes));
+      }
+    }
 
     // Save the zip file to the user specified location
     final zipBytes = ZipEncoder().encode(archive);

--- a/lib/features/settings/domain/usecase/export_data_usecase.dart
+++ b/lib/features/settings/domain/usecase/export_data_usecase.dart
@@ -11,6 +11,7 @@ import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_repository.dart';
 import 'package:path/path.dart' as p;
 import 'dart:io';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 
 class ExportDataUsecase {
   final UserActivityRepository _userActivityRepository;
@@ -115,7 +116,8 @@ class ExportDataUsecase {
     }
 
     for (final path in imagePaths) {
-      final file = File(path);
+      final absPath = await PathHelper.localImagePath(path);
+      final file = File(absPath);
       if (await file.exists()) {
         final bytes = await file.readAsBytes();
         final name = p.basename(path);

--- a/lib/features/settings/domain/usecase/import_data_supabase_usecase.dart
+++ b/lib/features/settings/domain/usecase/import_data_supabase_usecase.dart
@@ -121,7 +121,7 @@ class ImportDataSupabaseUsecase {
         final filePath = p.join(dir.path, fileName);
         final file = File(filePath);
         await file.writeAsBytes(imageFile.content as List<int>);
-        return file.path;
+        return fileName;
       }
 
       Future<MealDBO> convertMeal(MealDBO meal) async {

--- a/lib/features/settings/domain/usecase/import_data_usecase.dart
+++ b/lib/features/settings/domain/usecase/import_data_usecase.dart
@@ -11,24 +11,42 @@ import 'package:opennutritracker/core/data/repository/intake_repository.dart';
 import 'package:opennutritracker/core/data/repository/tracked_day_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_activity_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_weight_repository.dart';
+import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
+import 'package:opennutritracker/core/data/repository/user_repository.dart';
+import 'package:path/path.dart' as p;
+import 'package:path_provider/path_provider.dart';
+import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/intake_recipe_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/meal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_gender_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_pal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_weight_goal_dbo.dart';
+import 'package:opennutritracker/core/data/dbo/user_role_dbo.dart';
+import 'package:opennutritracker/core/domain/entity/user_entity.dart';
 
 class ImportDataUsecase {
   final UserActivityRepository _userActivityRepository;
   final IntakeRepository _intakeRepository;
   final TrackedDayRepository _trackedDayRepository;
   final UserWeightRepository _userWeightRepository;
+  final RecipeRepository _recipeRepository;
+  final UserRepository _userRepository;
 
   ImportDataUsecase(this._userActivityRepository, this._intakeRepository,
-      this._trackedDayRepository, this._userWeightRepository);
+      this._trackedDayRepository, this._userWeightRepository, this._recipeRepository, this._userRepository);
 
   /// Imports user activity, intake, and tracked day data from a zip file
   /// containing JSON files.
   ///
   /// Returns true if import was successful, false otherwise.
-  Future<bool> importData(String userActivityJsonFileName,
+  Future<bool> importData(
+      String userActivityJsonFileName,
       String userIntakeJsonFileName,
       String trackedDayJsonFileName,
-      String userWeightJsonFileName) async {
+      String userWeightJsonFileName,
+      String recipesJsonFileName,
+      String userJsonFileName) async {
     // Allow user to pick a zip file
     final result = await FilePicker.platform.pickFiles(
       type: FileType.any,
@@ -94,7 +112,9 @@ class ImportDataUsecase {
 
     // Extract and process user weight data
     final userWeightFile = archive.findFile(userWeightJsonFileName);
-    if (userWeightFile != null) {
+    final recipesFile = archive.findFile(recipesJsonFileName);
+    final userFile = archive.findFile(userJsonFileName);
+    if (userWeightFile != null && recipesFile != null && userFile != null) {
       final userWeightJsonString =
           utf8.decode(userWeightFile.content as List<int>);
       final userWeightList = (jsonDecode(userWeightJsonString) as List)
@@ -104,6 +124,92 @@ class ImportDataUsecase {
           userWeightList.map((json) => UserWeightDbo.fromJson(json)).toList();
 
       await _userWeightRepository.addAllUserWeightDBOs(userWeightDBOs);
+
+      final userJsonString = utf8.decode(userFile.content as List<int>);
+      final userMap = jsonDecode(userJsonString) as Map<String, dynamic>;
+      final dir = await getApplicationDocumentsDirectory();
+      String? profilePath;
+      if (userMap['profileImagePath'] != null) {
+        final imageName = userMap['profileImagePath'] as String;
+        final imageEntry = archive.findFile('images/$imageName');
+        if (imageEntry != null) {
+          final file = File(p.join(dir.path, imageName));
+          await file.writeAsBytes(imageEntry.content as List<int>);
+          profilePath = file.path;
+        }
+      }
+      final userDBO = UserDBO(
+        name: userMap['name'] as String,
+        birthday: DateTime.parse(userMap['birthday'] as String),
+        heightCM: (userMap['heightCM'] as num).toDouble(),
+        weightKG: (userMap['weightKG'] as num).toDouble(),
+        gender: UserGenderDBO.values[userMap['gender'] as int],
+        goal: UserWeightGoalDBO.values[userMap['goal'] as int],
+        pal: UserPALDBO.values[userMap['pal'] as int],
+        role: UserRoleDBO.values[userMap['role'] as int],
+        profileImagePath: profilePath,
+      );
+      await _userRepository.updateUserData(UserEntity.fromUserDBO(userDBO));
+
+      final recipesJsonString = utf8.decode(recipesFile.content as List<int>);
+      final recipesList =
+          (jsonDecode(recipesJsonString) as List).cast<Map<String, dynamic>>();
+      final recipesDBOs =
+          recipesList.map((e) => RecipesDBO.fromJson(e)).toList();
+
+      Future<MealDBO> convMeal(MealDBO meal) async {
+        String? copyPath(String? path) {
+          if (path == null || path.startsWith('http')) return null;
+          return p.basename(path);
+        }
+        String? stored(String? pName) {
+          if (pName == null) return null;
+          final entry = archive.findFile('images/$pName');
+          if (entry == null) return null;
+          final file = File(p.join(dir.path, pName));
+          file.writeAsBytesSync(entry.content as List<int>);
+          return file.path;
+        }
+
+        final thumb = stored(copyPath(meal.thumbnailImageUrl));
+        final main = stored(copyPath(meal.mainImageUrl));
+        final url = stored(copyPath(meal.url));
+        return MealDBO(
+          code: meal.code,
+          name: meal.name,
+          brands: meal.brands,
+          thumbnailImageUrl: thumb,
+          mainImageUrl: main,
+          url: url,
+          mealQuantity: meal.mealQuantity,
+          mealUnit: meal.mealUnit,
+          servingQuantity: meal.servingQuantity,
+          servingUnit: meal.servingUnit,
+          servingSize: meal.servingSize,
+          nutriments: meal.nutriments,
+          source: meal.source,
+        );
+      }
+      final List<RecipesDBO> updatedRecipes = [];
+      for (final r in recipesDBOs) {
+        final meal = await convMeal(r.recipe);
+        final updatedIngredients = <IntakeForRecipeDBO>[];
+        for (final ing in r.ingredients) {
+          final m = ing.meal;
+          final newMeal = m == null ? null : await convMeal(m);
+          updatedIngredients.add(IntakeForRecipeDBO(
+            code: ing.code,
+            name: ing.name,
+            unit: ing.unit,
+            amount: ing.amount,
+            meal: newMeal,
+          ));
+        }
+        updatedRecipes.add(RecipesDBO(recipe: meal, ingredients: updatedIngredients));
+      }
+      if (updatedRecipes.isNotEmpty) {
+        await _recipeRepository.addAllRecipeDBOs(updatedRecipes);
+      }
     } else {
       throw Exception('User weight file not found in the archive');
     }

--- a/lib/features/settings/domain/usecase/import_data_usecase.dart
+++ b/lib/features/settings/domain/usecase/import_data_usecase.dart
@@ -135,7 +135,7 @@ class ImportDataUsecase {
         if (imageEntry != null) {
           final file = File(p.join(dir.path, imageName));
           await file.writeAsBytes(imageEntry.content as List<int>);
-          profilePath = file.path;
+          profilePath = imageName;
         }
       }
       final userDBO = UserDBO(
@@ -168,7 +168,7 @@ class ImportDataUsecase {
           if (entry == null) return null;
           final file = File(p.join(dir.path, pName));
           file.writeAsBytesSync(entry.content as List<int>);
-          return file.path;
+          return pName;
         }
 
         final thumb = stored(copyPath(meal.thumbnailImageUrl));

--- a/lib/features/settings/presentation/bloc/export_import_bloc.dart
+++ b/lib/features/settings/presentation/bloc/export_import_bloc.dart
@@ -15,6 +15,8 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
   static const userIntakeJsonFileName = 'user_intake.json';
   static const trackedDayJsonFileName = 'user_tracked_day.json';
   static const userWeightJsonFileName = 'user_weight.json';
+  static const recipesJsonFileName = 'recipes.json';
+  static const userJsonFileName = 'user.json';
 
   final ExportDataUsecase _exportDataUsecase;
   final ImportDataUsecase _importDataUsecase;
@@ -34,6 +36,8 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
           userIntakeJsonFileName,
           trackedDayJsonFileName,
           userWeightJsonFileName,
+          recipesJsonFileName,
+          userJsonFileName,
         );
 
         if (result) {
@@ -56,6 +60,8 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
           userIntakeJsonFileName,
           trackedDayJsonFileName,
           userWeightJsonFileName,
+          recipesJsonFileName,
+          userJsonFileName,
         );
 
         if (result) {
@@ -76,7 +82,9 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
             userActivityJsonFileName,
             userIntakeJsonFileName,
             trackedDayJsonFileName,
-            userWeightJsonFileName);
+            userWeightJsonFileName,
+            recipesJsonFileName,
+            userJsonFileName);
         if (result) {
           emit(ExportImportSuccess());
         } else {
@@ -97,6 +105,8 @@ class ExportImportBloc extends Bloc<ExportImportEvent, ExportImportState> {
           userIntakeJsonFileName,
           trackedDayJsonFileName,
           userWeightJsonFileName,
+          recipesJsonFileName,
+          userJsonFileName,
         );
 
         if (result) {


### PR DESCRIPTION
## Summary
- export recipes and user info along with images in Supabase zip
- restore images and paths when importing from Supabase
- include recipe and user data in local import/export
- wire repositories into use cases and locator
- update bloc and auth flows to use new parameters

## Testing
- `flutter analyze`
- `flutter test`

------
https://chatgpt.com/codex/tasks/task_e_687605ff74d083218bce574476fe3c28