### PR TITLE
Use relative paths for stored images

### DIFF
--- a/lib/core/data/dbo/meal_dbo.dart
+++ b/lib/core/data/dbo/meal_dbo.dart
@@ -2,6 +2,7 @@ import 'package:hive_flutter/hive_flutter.dart';
 import 'package:json_annotation/json_annotation.dart';
 import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
+import 'package:path/path.dart' as p;
 
 part 'meal_dbo.g.dart';
 
@@ -61,9 +62,17 @@ class MealDBO extends HiveObject {
       code: mealEntity.code,
       name: mealEntity.name,
       brands: mealEntity.brands,
-      thumbnailImageUrl: mealEntity.thumbnailImageUrl,
-      mainImageUrl: mealEntity.mainImageUrl,
-      url: mealEntity.url,
+      thumbnailImageUrl: mealEntity.thumbnailImageUrl != null &&
+              !mealEntity.thumbnailImageUrl!.startsWith('http')
+          ? p.basename(mealEntity.thumbnailImageUrl!)
+          : mealEntity.thumbnailImageUrl,
+      mainImageUrl: mealEntity.mainImageUrl != null &&
+              !mealEntity.mainImageUrl!.startsWith('http')
+          ? p.basename(mealEntity.mainImageUrl!)
+          : mealEntity.mainImageUrl,
+      url: mealEntity.url != null && !mealEntity.url!.startsWith('http')
+          ? p.basename(mealEntity.url!)
+          : mealEntity.url,
       mealQuantity: mealEntity.mealQuantity,
       mealUnit: mealEntity.mealUnit,
       servingQuantity: mealEntity.servingQuantity,

--- a/lib/core/data/dbo/user_dbo.dart
+++ b/lib/core/data/dbo/user_dbo.dart
@@ -3,6 +3,7 @@ import 'package:opennutritracker/core/data/dbo/user_gender_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_pal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_weight_goal_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/user_role_dbo.dart';
+import 'package:path/path.dart' as p;
 import 'package:opennutritracker/core/domain/entity/user_entity.dart';
 
 part 'user_dbo.g.dart';
@@ -49,6 +50,8 @@ class UserDBO extends HiveObject {
         goal: UserWeightGoalDBO.fromUserWeightGoalEntity(entity.goal),
         pal: UserPALDBO.fromUserPALEntity(entity.pal),
         role: UserRoleDBO.fromUserRoleEntity(entity.role),
-        profileImagePath: entity.profileImagePath);
+        profileImagePath: entity.profileImagePath != null
+            ? p.basename(entity.profileImagePath!)
+            : null);
   }
 }

--- a/lib/core/domain/usecase/delete_recipe_usecase.dart
+++ b/lib/core/domain/usecase/delete_recipe_usecase.dart
@@ -1,5 +1,6 @@
 import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
 import 'dart:io';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 
 class DeleteRecipeUsecase {
   final RecipeRepository _recipeRepository;
@@ -17,7 +18,7 @@ class DeleteRecipeUsecase {
       ];
       for (final path in paths) {
         if (path != null && !path.startsWith('http')) {
-          final file = File(path);
+          final file = File(await PathHelper.localImagePath(path));
           if (await file.exists()) {
             try {
               await file.delete();

--- a/lib/core/presentation/widgets/image_full_screen.dart
+++ b/lib/core/presentation/widgets/image_full_screen.dart
@@ -4,6 +4,7 @@ import 'package:cached_network_image/cached_network_image.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_placeholder.dart';
 
 class ImageFullScreen extends StatefulWidget {
@@ -51,13 +52,22 @@ class _ImageFullScreenState extends State<ImageFullScreen> {
                   placeholder: (context, string) => const MealPlaceholder(),
                   errorWidget: (context, url, error) => const MealPlaceholder(),
                 )
-              : Image.file(
-                  File(imageUrl),
-                  width: double.infinity,
-                  height: double.infinity,
-                  fit: BoxFit.cover,
-                  errorBuilder: (context, error, stackTrace) =>
-                      const MealPlaceholder(),
+              : FutureBuilder<String>(
+                  future: PathHelper.localImagePath(imageUrl),
+                  builder: (context, snapshot) {
+                    final path = snapshot.data;
+                    if (path == null) {
+                      return const SizedBox.shrink();
+                    }
+                    return Image.file(
+                      File(path),
+                      width: double.infinity,
+                      height: double.infinity,
+                      fit: BoxFit.cover,
+                      errorBuilder: (context, error, stackTrace) =>
+                          const MealPlaceholder(),
+                    );
+                  },
                 ),
         ),
       ),

--- a/lib/core/presentation/widgets/intake_card.dart
+++ b/lib/core/presentation/widgets/intake_card.dart
@@ -6,6 +6,7 @@ import 'package:opennutritracker/core/domain/entity/intake_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/core/presentation/widgets/meal_value_unit_text.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 import 'dart:io';
 
 class IntakeCard extends StatelessWidget {
@@ -49,14 +50,23 @@ class IntakeCard extends StatelessWidget {
                 children: [
                   intake.meal.mainImageUrl != null
                       ? intake.meal.mealOrRecipe == MealOrRecipeEntity.recipe
-                          ? Container(
-                              decoration: BoxDecoration(
-                                image: DecorationImage(
-                                  image: FileImage(
-                                      File(intake.meal.mainImageUrl!)),
-                                  fit: BoxFit.cover,
-                                ),
-                              ),
+                          ? FutureBuilder<String>(
+                              future: PathHelper.localImagePath(
+                                  intake.meal.mainImageUrl!),
+                              builder: (context, snapshot) {
+                                final path = snapshot.data;
+                                if (path == null) {
+                                  return const SizedBox.shrink();
+                                }
+                                return Container(
+                                  decoration: BoxDecoration(
+                                    image: DecorationImage(
+                                      image: FileImage(File(path)),
+                                      fit: BoxFit.cover,
+                                    ),
+                                  ),
+                                );
+                              },
                             )
                           : CachedNetworkImage(
                               cacheManager: locator<CacheManager>(),

--- a/lib/core/utils/path_helper.dart
+++ b/lib/core/utils/path_helper.dart
@@ -1,0 +1,14 @@
+import 'package:path_provider/path_provider.dart';
+import 'package:path/path.dart' as p;
+import 'dart:io';
+
+class PathHelper {
+  static Directory? _overrideDir;
+
+  static set overrideDirectory(Directory? dir) => _overrideDir = dir;
+
+  static Future<String> localImagePath(String fileName) async {
+    final dir = _overrideDir ?? await getApplicationDocumentsDirectory();
+    return p.join(dir.path, fileName);
+  }
+}

--- a/lib/features/add_meal/presentation/widgets/meal_item_card.dart
+++ b/lib/features/add_meal/presentation/widgets/meal_item_card.dart
@@ -5,6 +5,7 @@ import 'package:flutter_cache_manager/flutter_cache_manager.dart';
 import 'package:opennutritracker/core/presentation/widgets/meal_value_unit_text.dart';
 import 'package:opennutritracker/core/utils/locator.dart';
 import 'package:opennutritracker/core/utils/navigation_options.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_or_recipe_entity.dart';
 import 'package:opennutritracker/features/add_meal/presentation/add_meal_type.dart';
@@ -41,11 +42,21 @@ class MealItemCard extends StatelessWidget {
                     mealEntity.thumbnailImageUrl != null
                 ? ClipRRect(
                     borderRadius: BorderRadius.circular(16),
-                    child: Image.file(
-                      File(mealEntity.thumbnailImageUrl!),
-                      width: 60,
-                      height: 60,
-                      fit: BoxFit.cover,
+                    child: FutureBuilder<String>(
+                      future: PathHelper.localImagePath(
+                          mealEntity.thumbnailImageUrl!),
+                      builder: (context, snapshot) {
+                        final path = snapshot.data;
+                        if (path == null) {
+                          return const SizedBox(width: 60, height: 60);
+                        }
+                        return Image.file(
+                          File(path),
+                          width: 60,
+                          height: 60,
+                          fit: BoxFit.cover,
+                        );
+                      },
                     ),
                   )
                 : mealEntity.thumbnailImageUrl != null

--- a/lib/features/create_meal/pick_image_screen.dart
+++ b/lib/features/create_meal/pick_image_screen.dart
@@ -41,6 +41,14 @@ class _PhotoPickerButtonState extends State<PhotoPickerButton> {
 
     if (pickedFile != null) {
       final imageFile = File(pickedFile.path);
+      if (_imagePath != null) {
+        final oldFile = File(_imagePath!);
+        if (await oldFile.exists()) {
+          try {
+            await oldFile.delete();
+          } catch (_) {}
+        }
+      }
       final now = DateTime.now();
       final formattedTime =
           '${now.year}${_twoDigits(now.month)}${_twoDigits(now.day)}_${_twoDigits(now.hour)}${_twoDigits(now.minute)}${_twoDigits(now.second)}';

--- a/lib/features/create_meal/pick_image_screen.dart
+++ b/lib/features/create_meal/pick_image_screen.dart
@@ -1,8 +1,8 @@
 import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
-import 'package:path_provider/path_provider.dart';
 import 'package:path/path.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 
 class PhotoPickerButton extends StatefulWidget {
   final void Function(String imagePath) onImagePicked;
@@ -25,7 +25,15 @@ class _PhotoPickerButtonState extends State<PhotoPickerButton> {
   @override
   void initState() {
     super.initState();
-    _imagePath = widget.initialImagePath;
+    if (widget.initialImagePath != null) {
+      PathHelper.localImagePath(widget.initialImagePath!).then((path) {
+        if (mounted) {
+          setState(() {
+            _imagePath = path;
+          });
+        }
+      });
+    }
   }
 
   Future<void> _takeAndStorePhoto() async {
@@ -33,14 +41,12 @@ class _PhotoPickerButtonState extends State<PhotoPickerButton> {
 
     if (pickedFile != null) {
       final imageFile = File(pickedFile.path);
-      final appDir = await getApplicationDocumentsDirectory();
-
       final now = DateTime.now();
       final formattedTime =
           '${now.year}${_twoDigits(now.month)}${_twoDigits(now.day)}_${_twoDigits(now.hour)}${_twoDigits(now.minute)}${_twoDigits(now.second)}';
       final fileName =
           'selected_photo_$formattedTime${extension(pickedFile.path)}';
-      final savedPath = '${appDir.path}/$fileName';
+      final savedPath = await PathHelper.localImagePath(fileName);
 
       final savedImage = await imageFile.copy(savedPath);
 
@@ -48,7 +54,7 @@ class _PhotoPickerButtonState extends State<PhotoPickerButton> {
         _imagePath = savedImage.path;
       });
 
-      widget.onImagePicked(savedImage.path);
+      widget.onImagePicked(fileName);
     }
   }
 

--- a/lib/features/meal_detail/meal_detail_screen.dart
+++ b/lib/features/meal_detail/meal_detail_screen.dart
@@ -18,6 +18,7 @@ import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_detail_nutriments_table.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_info_button.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_placeholder.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 import 'package:opennutritracker/features/meal_detail/presentation/widgets/meal_title_expanded.dart';
 import 'package:opennutritracker/core/domain/usecase/get_recipe_usecase.dart';
 import 'package:opennutritracker/generated/l10n.dart';
@@ -237,16 +238,26 @@ class _MealDetailScreenState extends State<MealDetailScreen> {
                       ? meal.mealOrRecipe == MealOrRecipeEntity.recipe
                           ? Hero(
                               tag: ImageFullScreen.fullScreenHeroTag,
-                              child: Container(
-                                width: 250,
-                                height: 250,
-                                decoration: BoxDecoration(
-                                  borderRadius: BorderRadius.circular(8),
-                                  image: DecorationImage(
-                                    image: FileImage(File(meal.mainImageUrl!)),
-                                    fit: BoxFit.cover,
-                                  ),
-                                ),
+                              child: FutureBuilder<String>(
+                                future: PathHelper.localImagePath(
+                                    meal.mainImageUrl!),
+                                builder: (context, snapshot) {
+                                  final path = snapshot.data;
+                                  if (path == null) {
+                                    return const SizedBox.shrink();
+                                  }
+                                  return Container(
+                                    width: 250,
+                                    height: 250,
+                                    decoration: BoxDecoration(
+                                      borderRadius: BorderRadius.circular(8),
+                                      image: DecorationImage(
+                                        image: FileImage(File(path)),
+                                        fit: BoxFit.cover,
+                                      ),
+                                    ),
+                                  );
+                                },
                               ),
                             )
                           : Hero(

--- a/lib/features/profile/presentation/widgets/profile_photo_picker.dart
+++ b/lib/features/profile/presentation/widgets/profile_photo_picker.dart
@@ -43,6 +43,14 @@ class _ProfilePhotoPickerState extends State<ProfilePhotoPicker> {
       final pickedFile = await _picker.pickImage(source: ImageSource.gallery);
       if (pickedFile != null) {
         final imageFile = File(pickedFile.path);
+        if (_imagePath != null) {
+          final oldFile = File(_imagePath!);
+          if (await oldFile.exists()) {
+            try {
+              await oldFile.delete();
+            } catch (_) {}
+          }
+        }
         final now = DateTime.now();
         final formattedTime =
             '${now.year}${_twoDigits(now.month)}${_twoDigits(now.day)}_${_twoDigits(now.hour)}${_twoDigits(now.minute)}${_twoDigits(now.second)}';
@@ -71,9 +79,8 @@ class _ProfilePhotoPickerState extends State<ProfilePhotoPicker> {
       onTap: _pickImage,
       child: CircleAvatar(
         radius: widget.size / 2,
-        backgroundImage: _imagePath != null
-            ? FileImage(File(_imagePath!))
-            : null,
+        backgroundImage:
+            _imagePath != null ? FileImage(File(_imagePath!)) : null,
         child: _imagePath == null
             ? Icon(Icons.camera_alt, size: widget.size / 3)
             : null,

--- a/lib/features/profile/presentation/widgets/profile_photo_picker.dart
+++ b/lib/features/profile/presentation/widgets/profile_photo_picker.dart
@@ -2,7 +2,7 @@ import 'dart:io';
 import 'package:flutter/material.dart';
 import 'package:image_picker/image_picker.dart';
 import 'package:path/path.dart' as p;
-import 'package:path_provider/path_provider.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 
 class ProfilePhotoPicker extends StatefulWidget {
   final void Function(String imagePath) onImagePicked;
@@ -27,7 +27,15 @@ class _ProfilePhotoPickerState extends State<ProfilePhotoPicker> {
   @override
   void initState() {
     super.initState();
-    _imagePath = widget.initialImagePath;
+    if (widget.initialImagePath != null) {
+      PathHelper.localImagePath(widget.initialImagePath!).then((path) {
+        if (mounted) {
+          setState(() {
+            _imagePath = path;
+          });
+        }
+      });
+    }
   }
 
   Future<void> _pickImage() async {
@@ -35,13 +43,12 @@ class _ProfilePhotoPickerState extends State<ProfilePhotoPicker> {
       final pickedFile = await _picker.pickImage(source: ImageSource.gallery);
       if (pickedFile != null) {
         final imageFile = File(pickedFile.path);
-        final appDir = await getApplicationDocumentsDirectory();
         final now = DateTime.now();
         final formattedTime =
             '${now.year}${_twoDigits(now.month)}${_twoDigits(now.day)}_${_twoDigits(now.hour)}${_twoDigits(now.minute)}${_twoDigits(now.second)}';
         final fileName =
             'profile_photo_$formattedTime${p.extension(pickedFile.path)}';
-        final savedPath = p.join(appDir.path, fileName);
+        final savedPath = await PathHelper.localImagePath(fileName);
 
         final savedImage = await imageFile.copy(savedPath);
 
@@ -49,7 +56,7 @@ class _ProfilePhotoPickerState extends State<ProfilePhotoPicker> {
         setState(() {
           _imagePath = savedImage.path;
         });
-        widget.onImagePicked(savedImage.path);
+        widget.onImagePicked(fileName);
       }
     } catch (e) {
       debugPrint('Failed to pick and save image: $e');

--- a/lib/features/settings/domain/usecase/export_data_supabase_usecase.dart
+++ b/lib/features/settings/domain/usecase/export_data_supabase_usecase.dart
@@ -12,6 +12,7 @@ import 'package:opennutritracker/core/data/repository/user_repository.dart';
 import 'package:path/path.dart' as p;
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:logging/logging.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 
 /// Exports user data to a zip file and uploads it to Supabase storage.
 class ExportDataSupabaseUsecase {
@@ -126,7 +127,7 @@ class ExportDataSupabaseUsecase {
     }
 
     for (final path in imagePaths) {
-      final file = File(path);
+      final file = File(await PathHelper.localImagePath(path));
       if (await file.exists()) {
         final bytes = await file.readAsBytes();
         final filename = p.basename(path);

--- a/lib/features/settings/domain/usecase/export_data_usecase.dart
+++ b/lib/features/settings/domain/usecase/export_data_usecase.dart
@@ -11,6 +11,7 @@ import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
 import 'package:opennutritracker/core/data/repository/user_repository.dart';
 import 'package:path/path.dart' as p;
 import 'dart:io';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 
 class ExportDataUsecase {
   final UserActivityRepository _userActivityRepository;
@@ -115,7 +116,8 @@ class ExportDataUsecase {
     }
 
     for (final path in imagePaths) {
-      final file = File(path);
+      final absPath = await PathHelper.localImagePath(path);
+      final file = File(absPath);
       if (await file.exists()) {
         final bytes = await file.readAsBytes();
         final name = p.basename(path);

--- a/lib/features/settings/domain/usecase/import_data_supabase_usecase.dart
+++ b/lib/features/settings/domain/usecase/import_data_supabase_usecase.dart
@@ -121,7 +121,7 @@ class ImportDataSupabaseUsecase {
         final filePath = p.join(dir.path, fileName);
         final file = File(filePath);
         await file.writeAsBytes(imageFile.content as List<int>);
-        return file.path;
+        return fileName;
       }
 
       Future<MealDBO> convertMeal(MealDBO meal) async {

--- a/lib/features/settings/domain/usecase/import_data_usecase.dart
+++ b/lib/features/settings/domain/usecase/import_data_usecase.dart
@@ -135,7 +135,7 @@ class ImportDataUsecase {
         if (imageEntry != null) {
           final file = File(p.join(dir.path, imageName));
           await file.writeAsBytes(imageEntry.content as List<int>);
-          profilePath = file.path;
+          profilePath = imageName;
         }
       }
       final userDBO = UserDBO(
@@ -168,7 +168,7 @@ class ImportDataUsecase {
           if (entry == null) return null;
           final file = File(p.join(dir.path, pName));
           file.writeAsBytesSync(entry.content as List<int>);
-          return file.path;
+          return pName;
         }
 
         final thumb = stored(copyPath(meal.thumbnailImageUrl));

--- a/test/unit_test/recipe_repository_test.dart
+++ b/test/unit_test/recipe_repository_test.dart
@@ -18,7 +18,6 @@ import 'package:opennutritracker/core/data/dbo/intake_recipe_dbo.dart';
 
 import '../fixture/recipe_entity_fixtures.dart';
 
-
 void main() {
   group('Recipe add/replace logic', () {
     late Box<RecipesDBO> box;
@@ -102,6 +101,7 @@ void main() {
       TestWidgetsFlutterBinding.ensureInitialized();
       tempDir = await Directory.systemTemp.createTemp('hive_test_del_');
       Hive.init(tempDir.path);
+      PathHelper.overrideDirectory = tempDir;
 
       box = await Hive.openBox<RecipesDBO>('recipes_test');
       final hive = HiveDBProvider();
@@ -117,6 +117,7 @@ void main() {
       await Hive.deleteFromDisk();
       locator.reset();
       await tempDir.delete(recursive: true);
+      PathHelper.overrideDirectory = null;
     });
 
     test('delete removes recipe and local image', () async {

--- a/test/unit_test/recipe_repository_test.dart
+++ b/test/unit_test/recipe_repository_test.dart
@@ -8,6 +8,7 @@ import 'package:opennutritracker/core/data/dbo/meal_nutriments_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/meal_or_recipe_dbo.dart';
 import 'package:opennutritracker/core/data/dbo/recipe_dbo.dart';
 import 'package:opennutritracker/core/data/repository/recipe_repository.dart';
+import 'package:opennutritracker/core/utils/path_helper.dart';
 import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 import 'package:opennutritracker/features/add_meal/domain/entity/meal_entity.dart';
 import 'package:opennutritracker/core/domain/usecase/add_recipe_usecase.dart';
@@ -28,6 +29,7 @@ void main() {
 
       tempDir = await Directory.systemTemp.createTemp('hive_test_');
       Hive.init(tempDir.path);
+      PathHelper.overrideDirectory = tempDir;
 
       Hive.registerAdapter(RecipesDBOAdapter());
       Hive.registerAdapter(MealDBOAdapter());
@@ -53,6 +55,7 @@ void main() {
       await Hive.deleteFromDisk();
       locator.reset();
       await tempDir.delete(recursive: true);
+      PathHelper.overrideDirectory = null;
     });
 
     test('remplace une recette existante par une nouvelle', () async {
@@ -117,16 +120,16 @@ void main() {
     });
 
     test('delete removes recipe and local image', () async {
-      final imagePath = '${tempDir.path}/img.png';
+      final imagePath = await PathHelper.localImagePath('img.png');
       final imageFile = File(imagePath);
       await imageFile.writeAsString('test');
 
       final recipe = RecipeEntityFixtures.basicRecipe.copyWith(
         meal: RecipeEntityFixtures.basicRecipe.meal.copyWith(
           code: 'to_delete',
-          url: imagePath,
-          thumbnailImageUrl: imagePath,
-          mainImageUrl: imagePath,
+          url: 'img.png',
+          thumbnailImageUrl: 'img.png',
+          mainImageUrl: 'img.png',
         ),
       );
       await locator<AddRecipeUsecase>().addRecipe(recipe);


### PR DESCRIPTION
## Summary
- add `PathHelper.localImagePath` to resolve images relative to the documents directory
- store only image file names in `UserDBO` and `MealDBO`
- adjust widgets and screens to pass relative names and resolve them with `PathHelper`
- update import/export logic to work with relative paths
- update recipe repository tests for new path behaviour

## Testing
- `flutter pub get` *(fails: could not download SDK)*
- `flutter analyze` *(not run due to previous failure)*
- `flutter test` *(not run due to previous failure)*

------
https://chatgpt.com/codex/tasks/task_e_68768b4657a48321a000cab63a4da0b6