### PR TITLE
Add user weight sync to Supabase

### DIFF
--- a/lib/core/data/data_source/user_weight_dbo.dart
+++ b/lib/core/data/data_source/user_weight_dbo.dart
@@ -15,17 +15,14 @@ class UserWeightDbo extends HiveObject {
   final DateTime date;
 
   @HiveField(3)
-  final DateTime updatedAt;
+  final DateTime updated_at;
 
-  UserWeightDbo(this.id, this.weight, this.date, this.updatedAt);
+  UserWeightDbo(this.id, this.weight, this.date, this.updated_at);
 
   factory UserWeightDbo.fromUserWeightEntity(
       UserWeightEntity userWeightEntity) {
-    return UserWeightDbo(
-        userWeightEntity.id,
-        userWeightEntity.weight,
-        userWeightEntity.date,
-        userWeightEntity.updatedAt);
+    return UserWeightDbo(userWeightEntity.id, userWeightEntity.weight,
+        userWeightEntity.date, userWeightEntity.updatedAt);
   }
 
   factory UserWeightDbo.fromJson(Map<String, dynamic> json) =>

--- a/lib/core/data/data_source/user_weight_dbo.dart
+++ b/lib/core/data/data_source/user_weight_dbo.dart
@@ -15,9 +15,9 @@ class UserWeightDbo extends HiveObject {
   final DateTime date;
 
   @HiveField(3)
-  final DateTime updated_at;
+  final DateTime updatedat;
 
-  UserWeightDbo(this.id, this.weight, this.date, this.updated_at);
+  UserWeightDbo(this.id, this.weight, this.date, this.updatedat);
 
   factory UserWeightDbo.fromUserWeightEntity(
       UserWeightEntity userWeightEntity) {

--- a/lib/core/data/data_source/user_weight_dbo.g.dart
+++ b/lib/core/data/data_source/user_weight_dbo.g.dart
@@ -35,7 +35,7 @@ class UserWeightDboAdapter extends TypeAdapter<UserWeightDbo> {
       ..writeByte(2)
       ..write(obj.date)
       ..writeByte(3)
-      ..write(obj.updated_at);
+      ..write(obj.updatedat);
   }
 
   @override
@@ -58,7 +58,7 @@ UserWeightDbo _$UserWeightDboFromJson(Map<String, dynamic> json) =>
       json['id'] as String,
       (json['weight'] as num).toDouble(),
       DateTime.parse(json['date'] as String),
-      DateTime.parse(json['updated_at'] as String),
+      DateTime.parse(json['updatedat'] as String),
     );
 
 Map<String, dynamic> _$UserWeightDboToJson(UserWeightDbo instance) =>
@@ -66,5 +66,5 @@ Map<String, dynamic> _$UserWeightDboToJson(UserWeightDbo instance) =>
       'id': instance.id,
       'weight': instance.weight,
       'date': instance.date.toIso8601String(),
-      'updated_at': instance.updated_at.toIso8601String(),
+      'updatedat': instance.updatedat.toIso8601String(),
     };

--- a/lib/core/data/data_source/user_weight_dbo.g.dart
+++ b/lib/core/data/data_source/user_weight_dbo.g.dart
@@ -35,7 +35,7 @@ class UserWeightDboAdapter extends TypeAdapter<UserWeightDbo> {
       ..writeByte(2)
       ..write(obj.date)
       ..writeByte(3)
-      ..write(obj.updatedAt);
+      ..write(obj.updated_at);
   }
 
   @override
@@ -58,7 +58,7 @@ UserWeightDbo _$UserWeightDboFromJson(Map<String, dynamic> json) =>
       json['id'] as String,
       (json['weight'] as num).toDouble(),
       DateTime.parse(json['date'] as String),
-      DateTime.parse(json['updatedAt'] as String),
+      DateTime.parse(json['updated_at'] as String),
     );
 
 Map<String, dynamic> _$UserWeightDboToJson(UserWeightDbo instance) =>
@@ -66,5 +66,5 @@ Map<String, dynamic> _$UserWeightDboToJson(UserWeightDbo instance) =>
       'id': instance.id,
       'weight': instance.weight,
       'date': instance.date.toIso8601String(),
-      'updatedAt': instance.updatedAt.toIso8601String(),
+      'updated_at': instance.updated_at.toIso8601String(),
     };

--- a/lib/core/domain/entity/user_weight_entity.dart
+++ b/lib/core/domain/entity/user_weight_entity.dart
@@ -19,7 +19,7 @@ class UserWeightEntity {
       id: userWeightDbo.id,
       weight: userWeightDbo.weight,
       date: userWeightDbo.date,
-      updatedAt: userWeightDbo.updated_at,
+      updatedAt: userWeightDbo.updatedat,
     );
   }
 

--- a/lib/core/domain/entity/user_weight_entity.dart
+++ b/lib/core/domain/entity/user_weight_entity.dart
@@ -19,7 +19,7 @@ class UserWeightEntity {
       id: userWeightDbo.id,
       weight: userWeightDbo.weight,
       date: userWeightDbo.date,
-      updatedAt: userWeightDbo.updatedAt,
+      updatedAt: userWeightDbo.updated_at,
     );
   }
 

--- a/lib/features/settings/domain/usecase/import_data_supabase_usecase.dart
+++ b/lib/features/settings/domain/usecase/import_data_supabase_usecase.dart
@@ -103,8 +103,14 @@ class ImportDataSupabaseUsecase {
       final recipesFile = archive.findFile(recipesJsonFileName);
       final userFile = archive.findFile(userJsonFileName);
 
-      if ([userActivityFile, intakeFile, trackedDayFile, userWeightFile, recipesFile, userFile]
-          .any((f) => f == null)) {
+      if ([
+        userActivityFile,
+        intakeFile,
+        trackedDayFile,
+        userWeightFile,
+        recipesFile,
+        userFile
+      ].any((f) => f == null)) {
         throw Exception('Archive is missing required files');
       }
 
@@ -307,7 +313,7 @@ class ImportDataSupabaseUsecase {
         final current = weightMap[key];
         if (current == null) {
           await _userWeightRepository.addAllUserWeightDBOs([dbo]);
-        } else if (dbo.updatedAt.isAfter(current.updatedAt)) {
+        } else if (dbo.updated_at.isAfter(current.updated_at)) {
           await _userWeightRepository.deleteUserWeightByDate(current.date);
           await _userWeightRepository.addAllUserWeightDBOs([dbo]);
         }

--- a/lib/features/settings/domain/usecase/import_data_supabase_usecase.dart
+++ b/lib/features/settings/domain/usecase/import_data_supabase_usecase.dart
@@ -313,7 +313,7 @@ class ImportDataSupabaseUsecase {
         final current = weightMap[key];
         if (current == null) {
           await _userWeightRepository.addAllUserWeightDBOs([dbo]);
-        } else if (dbo.updated_at.isAfter(current.updated_at)) {
+        } else if (dbo.updatedat.isAfter(current.updatedat)) {
           await _userWeightRepository.deleteUserWeightByDate(current.date);
           await _userWeightRepository.addAllUserWeightDBOs([dbo]);
         }

--- a/lib/features/sync/supabase_client.dart
+++ b/lib/features/sync/supabase_client.dart
@@ -42,3 +42,45 @@ class SupabaseTrackedDayService {
     }
   }
 }
+
+class SupabaseUserWeightService {
+  final SupabaseClient _client;
+  final _log = Logger('SupabaseUserWeightService');
+
+  SupabaseUserWeightService({SupabaseClient? client})
+      : _client = client ?? locator<SupabaseClient>();
+
+  /// Upserts a single user weight entry.
+  /// Logs any exception that occurs during the operation.
+  Future<void> upsertUserWeight(Map<String, dynamic> json) async {
+    try {
+      await _client.from('user_weight').upsert(json, onConflict: 'date');
+    } catch (e, stackTrace) {
+      _log.severe('Failed to upsert user weight: $e', e, stackTrace);
+    }
+  }
+
+  /// Upserts multiple user weight entries in bulk.
+  /// If the list is empty, the function exits early.
+  /// Logs any exception that occurs during the operation.
+  Future<void> upsertUserWeights(List<Map<String, dynamic>> weights) async {
+    if (weights.isEmpty) return;
+    try {
+      await _client.from('user_weight').upsert(weights, onConflict: 'date');
+    } catch (e, stackTrace) {
+      _log.severe('Failed to upsert user weights: $e', e, stackTrace);
+    }
+  }
+
+  /// Deletes a user weight entry based on the provided date.
+  /// Logs any exception that occurs during the operation.
+  Future<void> deleteUserWeight(DateTime date) async {
+    final iso = date.toIso8601String();
+    try {
+      await _client.from('user_weight').delete().eq('date', iso);
+    } catch (e, stackTrace) {
+      _log.severe('Failed to delete user weight: $e', e, stackTrace);
+    }
+  }
+}
+

--- a/lib/features/sync/user_weight_change_isolate.dart
+++ b/lib/features/sync/user_weight_change_isolate.dart
@@ -1,0 +1,133 @@
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:hive_flutter/hive_flutter.dart';
+import 'package:logging/logging.dart';
+import 'package:opennutritracker/core/data/data_source/user_weight_dbo.dart';
+import 'package:opennutritracker/core/utils/locator.dart';
+import 'package:opennutritracker/features/sync/change_isolate.dart';
+import 'package:opennutritracker/features/sync/supabase_client.dart';
+
+/// Watches a [UserWeightDbo] box and synchronizes modified weights
+/// with Supabase as soon as a connection is available.
+class UserWeightChangeIsolate extends ChangeIsolate<DateTime> {
+  final SupabaseUserWeightService _service;
+  final Connectivity _connectivity;
+  final int batchSize;
+  StreamSubscription<ConnectivityResult>? _connectivitySub;
+  bool _syncing = false;
+  final Logger _log = Logger('UserWeightChangeIsolate');
+
+  UserWeightChangeIsolate(
+    Box<UserWeightDbo> box, {
+    SupabaseUserWeightService? service,
+    Connectivity? connectivity,
+    this.batchSize = 20,
+  })  : _service = service ?? SupabaseUserWeightService(),
+        _connectivity = connectivity ?? locator<Connectivity>(),
+        super(
+          box: box,
+          extractor: (event) {
+            final value = event.value;
+            if (value is UserWeightDbo) return value.date;
+            return null;
+          },
+          onItemCollected: null,
+        );
+
+  /// Convenient proxy to get the pending weight dates.
+  Future<List<DateTime>> getModifiedWeights() => getItems();
+
+  /* ---------- Lifecycle ---------- */
+
+  @override
+  Future<void> start() async {
+    _log.info('Starting UserWeightChangeIsolate...');
+    onItemCollected ??= _attemptSync;
+
+    await super.start();
+    _log.fine('ChangeIsolate started.');
+
+    await _attemptSync();
+
+    _connectivitySub =
+        _connectivity.onConnectivityChanged.listen(_onConnectivityChanged);
+    _log.fine('Connectivity listener started.');
+  }
+
+  @override
+  Future<void> stop() async {
+    _log.info('Stopping UserWeightChangeIsolate...');
+    await _connectivitySub?.cancel();
+    _connectivitySub = null;
+    await super.stop();
+    _log.info('UserWeightChangeIsolate stopped.');
+  }
+
+  /* ---------- Connectivity management ---------- */
+
+  void _onConnectivityChanged(ConnectivityResult result) {
+    _log.fine('Connectivity changed: $result');
+    if (result != ConnectivityResult.none) {
+      _log.fine('Internet available, attempting sync...');
+      _attemptSync();
+    } else {
+      _log.fine('No internet connection.');
+    }
+  }
+
+  /* ---------- Supabase sync ---------- */
+
+  String _keyForDate(DateTime date) =>
+      DateTime(date.year, date.month, date.day).toString();
+
+  Future<void> _attemptSync() async {
+    if (_syncing) {
+      _log.fine('Sync already in progress, skipping.');
+      return;
+    }
+    _syncing = true;
+    try {
+      if (await _connectivity.checkConnectivity() == ConnectivityResult.none) {
+        _log.fine('No connectivity, aborting sync.');
+        return;
+      }
+
+      final dates = await getModifiedWeights();
+      if (dates.isEmpty) {
+        _log.fine('No modified weights to sync.');
+        return;
+      }
+
+      _log.info('Starting sync for ${dates.length} weights.');
+      for (var i = 0; i < dates.length; i += batchSize) {
+        final batch = dates.skip(i).take(batchSize).toList();
+        final entries = <Map<String, dynamic>>[];
+
+        for (final date in batch) {
+          final dbo = box.get(_keyForDate(date)) as UserWeightDbo?;
+          if (dbo != null) entries.add(dbo.toJson());
+        }
+
+        if (entries.isNotEmpty) {
+          if (await _connectivity.checkConnectivity() ==
+              ConnectivityResult.none) {
+            _log.warning('Lost connectivity during sync, will retry later.');
+            break;
+          }
+
+          _log.info('Upserting ${entries.length} user weights to Supabase.');
+          await _service.upsertUserWeights(entries);
+          await removeItems(batch);
+          _log.fine('Batch of ${batch.length} weights synced and removed.');
+        }
+      }
+      _log.info('Sync completed.');
+    } catch (e, stack) {
+      _log.severe('Sync failed: $e', e, stack);
+    } finally {
+      _syncing = false;
+    }
+  }
+}
+

--- a/test/unit_test/supabase_client_test.dart
+++ b/test/unit_test/supabase_client_test.dart
@@ -7,6 +7,7 @@ void main() {
   late final SupabaseClient mockSupabase;
   late final MockSupabaseHttpClient mockHttpClient;
   late final SupabaseTrackedDayService trackedDayService;
+  late final SupabaseUserWeightService weightService;
 
   setUpAll(() {
     mockHttpClient = MockSupabaseHttpClient();
@@ -19,6 +20,7 @@ void main() {
     );
 
     trackedDayService = SupabaseTrackedDayService(client: mockSupabase);
+    weightService = SupabaseUserWeightService(client: mockSupabase);
   });
 
   tearDown(() async {
@@ -119,5 +121,35 @@ void main() {
 
     final result = await mockSupabase.from('tracked_days').select();
     expect(result, isEmpty);
+  });
+
+  group('SupabaseUserWeightService', () {
+    test('upserting a single weight works', () async {
+      final date = DateTime.now();
+      await weightService.upsertUserWeight({
+        'id': '1',
+        'weight': 80,
+        'date': date.toIso8601String(),
+        'updatedAt': date.toIso8601String(),
+      });
+
+      final result = await mockSupabase.from('user_weight').select();
+      expect(result.length, 1);
+      expect(result.first['date'], date.toIso8601String());
+    });
+
+    test('deleting a user weight works', () async {
+      final date = DateTime.now();
+      await weightService.upsertUserWeight({
+        'id': '2',
+        'weight': 81,
+        'date': date.toIso8601String(),
+        'updatedAt': date.toIso8601String(),
+      });
+
+      await weightService.deleteUserWeight(date);
+      final result = await mockSupabase.from('user_weight').select();
+      expect(result, isEmpty);
+    });
   });
 }

--- a/test/unit_test/user_weight_change_isolate_test.dart
+++ b/test/unit_test/user_weight_change_isolate_test.dart
@@ -1,0 +1,141 @@
+import 'dart:io';
+import 'dart:async';
+
+import 'package:connectivity_plus/connectivity_plus.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:hive/hive.dart';
+import 'package:mock_supabase_http_client/mock_supabase_http_client.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
+import 'package:opennutritracker/core/data/data_source/user_weight_dbo.dart';
+import 'package:opennutritracker/core/data/repository/user_weight_repository.dart';
+import 'package:opennutritracker/core/data/data_source/user_weight_data_source.dart';
+import 'package:opennutritracker/core/domain/entity/user_weight_entity.dart';
+import 'package:opennutritracker/core/utils/id_generator.dart';
+import 'package:opennutritracker/features/sync/user_weight_change_isolate.dart';
+import 'package:opennutritracker/features/sync/supabase_client.dart';
+import 'package:supabase_flutter/supabase_flutter.dart';
+import 'package:mocktail/mocktail.dart';
+
+class FakeConnectivity extends Mock implements Connectivity {
+  final _controller = StreamController<ConnectivityResult>.broadcast();
+  ConnectivityResult _result = ConnectivityResult.none;
+
+  @override
+  Stream<ConnectivityResult> get onConnectivityChanged => _controller.stream;
+
+  @override
+  Future<ConnectivityResult> checkConnectivity() async => _result;
+
+  void emit(ConnectivityResult result) {
+    _result = result;
+    _controller.add(result);
+  }
+
+  Future<void> close() async {
+    await _controller.close();
+  }
+}
+
+Future<void> waitForCondition(
+  Future<bool> Function() condition, {
+  Duration timeout = const Duration(seconds: 2),
+}) async {
+  final end = DateTime.now().add(timeout);
+  while (DateTime.now().isBefore(end)) {
+    if (await condition()) return;
+    await Future.delayed(const Duration(milliseconds: 10));
+  }
+  throw TimeoutException('Condition not met within $timeout');
+}
+
+void main() {
+  group('UserWeightChangeIsolate', () {
+    late Directory tempDir;
+    late Box<UserWeightDbo> box;
+    late UserWeightChangeIsolate watcher;
+    late FakeConnectivity connectivity;
+    late SupabaseClient mockSupabase;
+    late MockSupabaseHttpClient mockHttpClient;
+    late SupabaseUserWeightService weightService;
+    late UserWeightRepository repo;
+
+    setUp(() async {
+      TestWidgetsFlutterBinding.ensureInitialized();
+
+      tempDir = await Directory.systemTemp.createTemp('hive_test_isolate_');
+      Hive.init(tempDir.path);
+      if (!Hive.isAdapterRegistered(18)) {
+        Hive.registerAdapter(UserWeightDboAdapter());
+      }
+      box = await Hive.openBox<UserWeightDbo>('user_weight_test');
+      final hive = HiveDBProvider();
+      hive.userWeightBox = box;
+
+      repo = UserWeightRepository(UserWeightDataSource(hive));
+
+      mockHttpClient = MockSupabaseHttpClient();
+      mockSupabase = SupabaseClient(
+        'https://mock.supabase.co',
+        'fakeAnonKey',
+        httpClient: mockHttpClient,
+      );
+      weightService = SupabaseUserWeightService(client: mockSupabase);
+
+      connectivity = FakeConnectivity();
+
+      watcher = UserWeightChangeIsolate(
+        box,
+        service: weightService,
+        connectivity: connectivity,
+      );
+      await watcher.start();
+    });
+
+    tearDown(() async {
+      await watcher.stop();
+      await connectivity.close();
+      await box.close();
+      await Hive.deleteFromDisk();
+      await tempDir.delete(recursive: true);
+    });
+
+    test('captures modified weight when box updates', () async {
+      final date = DateTime.utc(2024, 1, 1);
+      final entity = UserWeightEntity(
+        id: IdGenerator.getUniqueID(),
+        weight: 80,
+        date: date,
+      );
+      await repo.addUserWeight(entity);
+
+      await waitForCondition(
+          () async => (await watcher.getModifiedWeights()).contains(date));
+
+      final modified = await watcher.getModifiedWeights();
+      expect(modified, contains(date));
+    });
+
+    test('syncs modified weights when connectivity is restored', () async {
+      final date = DateTime.utc(2024, 1, 2);
+      await repo.addUserWeight(
+        UserWeightEntity(
+          id: IdGenerator.getUniqueID(),
+          weight: 81,
+          date: date,
+        ),
+      );
+
+      await waitForCondition(
+          () async => (await watcher.getModifiedWeights()).contains(date));
+
+      connectivity.emit(ConnectivityResult.wifi);
+
+      await waitForCondition(
+          () async => (await watcher.getModifiedWeights()).isEmpty);
+
+      final result = await mockSupabase.from('user_weight').select();
+      expect(result.length, 1);
+      expect(DateTime.parse(result.first['date']), date);
+    });
+  });
+}


### PR DESCRIPTION
## Summary
- add `SupabaseUserWeightService` to handle `user_weight` table
- create `UserWeightChangeIsolate` for syncing weight entries
- start/stop the new isolate in `HiveDBProvider`
- cover weight service and isolate with unit tests

## Testing
- `flutter pub get` *(fails: command not found)*
- `flutter analyze` *(fails: command not found)*
- `flutter test` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68864f58bdbc83218ac22550d8978387