### PR TITLE
Rename OpenNutriTracker references

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,18 +5,18 @@
     "version": "0.2.0",
     "configurations": [
         {
-            "name": "OpenNutriTracker",
+            "name": "AtlasTracker",
             "request": "launch",
             "type": "dart"
         },
         {
-            "name": "OpenNutriTracker (profile mode)",
+            "name": "AtlasTracker (profile mode)",
             "request": "launch",
             "type": "dart",
             "flutterMode": "profile"
         },
         {
-            "name": "OpenNutriTracker (release mode)",
+            "name": "AtlasTracker (release mode)",
             "request": "launch",
             "type": "dart",
             "flutterMode": "release"

--- a/README.md
+++ b/README.md
@@ -19,7 +19,7 @@
 ## Description
 AtlasTracker is an open-source mobile application designed to simplify nutritional tracking and management. Whether you are looking to improve your health, lose weight, or simply maintain a balanced diet, AtlasTracker provides a minimalistic interface to easily track and analyze your daily nutrition.
 
-[Website](https://simonoppowa.github.io/OpenNutriTracker-Website/)
+[Website](https://simonoppowa.github.io/AtlasTracker-Website/)
 
 ## Screenshots
 <p align="center">

--- a/android/app/src/main/AndroidManifest.xml
+++ b/android/app/src/main/AndroidManifest.xml
@@ -16,7 +16,7 @@
     </queries>
 
    <application
-        android:label="OpenNutriTracker"
+       android:label="AtlasTracker"
         android:name="${applicationName}"
         android:icon="@mipmap/ic_launcher">
         <activity

--- a/fastlane/metadata/android/en-US/full_description.txt
+++ b/fastlane/metadata/android/en-US/full_description.txt
@@ -1,9 +1,9 @@
-OpenNutriTracker is an open-source mobile application designed to simplify nutritional tracking and management. Whether you are looking to improve your health, lose weight, or simply maintain a balanced diet, OpenNutriTracker provides a minimalistic interface to easily track and analyze your daily nutrition.
+AtlasTracker is an open-source mobile application designed to simplify nutritional tracking and management. Whether you are looking to improve your health, lose weight, or simply maintain a balanced diet, AtlasTracker provides a minimalistic interface to easily track and analyze your daily nutrition.
 
 
 🍎 Nutritional Tracking: Easily log your meals and snacks, and access a vast database of food items and ingredients to get detailed nutritional information.
 📓 Food Diary: Maintain a comprehensive food diary to keep track of your daily food consumption, habits, and progress.
 🍽️ Custom Meals: Plan your meals in advance, create personalized meal plans, and optimize them according to your dietary goals.
 📷 Barcode Scanner: Scan barcodes on packaged food items to instantly retrieve their nutritional information.
-🔒 Privacy Focused: OpenNutriTracker prioritizes the privacy its users. It does not collect or share any personal data without your consent.
-🚫💰 No Subscription, In-App Purchases, or Ads: OpenNutriTracker is completely free to use, without any subscription fees, in-app purchases, or intrusive advertisements.
+🔒 Privacy Focused: AtlasTracker prioritizes the privacy its users. It does not collect or share any personal data without your consent.
+🚫💰 No Subscription, In-App Purchases, or Ads: AtlasTracker is completely free to use, without any subscription fees, in-app purchases, or intrusive advertisements.

--- a/fastlane/metadata/android/en-US/title.txt
+++ b/fastlane/metadata/android/en-US/title.txt
@@ -1,1 +1,1 @@
-OpenNutriTracker
+AtlasTracker

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleDevelopmentRegion</key>
 	<string>$(DEVELOPMENT_LANGUAGE)</string>
 	<key>CFBundleDisplayName</key>
-	<string>OpenNutriTracker</string>
+       <string>AtlasTracker</string>
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>

--- a/lib/core/utils/app_const.dart
+++ b/lib/core/utils/app_const.dart
@@ -2,12 +2,12 @@ import 'dart:io' show Platform;
 import 'package:package_info_plus/package_info_plus.dart';
 
 class AppConst {
-  static const userAgentAppName = "OpenNutriTracker";
+  static const userAgentAppName = "AtlasTracker";
   static const platformNameAndroid = "Android";
   static const platformNameIOS = "iOS";
-  static const reportErrorEmail = "opennutritracker-dev@pm.me";
+  static const reportErrorEmail = "AtlasTracker-dev@pm.me";
   static const sourceCodeUrl =
-      "https://github.com/simonoppowa/OpenNutriTracker";
+      "https://github.com/simonoppowa/AtlasTracker";
 
   static Future<String> getVersionNumber() async {
     PackageInfo packageInfo = await PackageInfo.fromPlatform();

--- a/lib/generated/intl/messages_de.dart
+++ b/lib/generated/intl/messages_de.dart
@@ -51,10 +51,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "allItemsLabel": MessageLookupByLibrary.simpleMessage("Alle"),
         "alphaVersionName": MessageLookupByLibrary.simpleMessage("[Alpha]"),
         "appDescription": MessageLookupByLibrary.simpleMessage(
-            "OpenNutriTracker ist ein kostenloser und  quelloffener Kalorien- und Nährstofftracker, der Ihre Privatsphäre respektiert."),
+            "AtlasTracker ist ein kostenloser und  quelloffener Kalorien- und Nährstofftracker, der Ihre Privatsphäre respektiert."),
         "appLicenseLabel":
             MessageLookupByLibrary.simpleMessage("GPL-3.0 Lizenz"),
-        "appTitle": MessageLookupByLibrary.simpleMessage("OpenNutriTracker"),
+        "appTitle": MessageLookupByLibrary.simpleMessage("AtlasTracker"),
         "appVersionName": m0,
         "betaVersionName": MessageLookupByLibrary.simpleMessage("[Beta]"),
         "bmiInfo": MessageLookupByLibrary.simpleMessage(

--- a/lib/generated/intl/messages_en.dart
+++ b/lib/generated/intl/messages_en.dart
@@ -50,10 +50,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "allItemsLabel": MessageLookupByLibrary.simpleMessage("All"),
         "alphaVersionName": MessageLookupByLibrary.simpleMessage("[Alpha]"),
         "appDescription": MessageLookupByLibrary.simpleMessage(
-            "OpenNutriTracker is a free and open-source calorie and nutrient tracker that respects your privacy."),
+            "AtlasTracker is a free and open-source calorie and nutrient tracker that respects your privacy."),
         "appLicenseLabel":
             MessageLookupByLibrary.simpleMessage("GPL-3.0 license"),
-        "appTitle": MessageLookupByLibrary.simpleMessage("OpenNutriTracker"),
+        "appTitle": MessageLookupByLibrary.simpleMessage("AtlasTracker"),
         "appVersionName": m0,
         "averageWeightBody": MessageLookupByLibrary.simpleMessage(
             "Average user weight over the last seven days. The current day is not counted."),

--- a/lib/generated/intl/messages_fr.dart
+++ b/lib/generated/intl/messages_fr.dart
@@ -42,7 +42,7 @@ class MessageLookup extends MessageLookupByLibrary {
         "additionalInfoLabelCustom":
             MessageLookupByLibrary.simpleMessage("Aliment personnalisé"),
         "additionalInfoLabelFDC": MessageLookupByLibrary.simpleMessage(
-            "Plus d\'informations sur\nciqual.anses.fr"),
+            "Plus d\'informations sur\nFoodData Central"),
         "additionalInfoLabelOFF": MessageLookupByLibrary.simpleMessage(
             "Plus d\'informations sur\nOpenFoodFacts"),
         "additionalInfoLabelUnknown":
@@ -51,10 +51,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "allItemsLabel": MessageLookupByLibrary.simpleMessage("Tous"),
         "alphaVersionName": MessageLookupByLibrary.simpleMessage("[Alpha]"),
         "appDescription": MessageLookupByLibrary.simpleMessage(
-            "OpenNutriTracker est un traqueur de calories et de nutriments gratuit et open-source qui respecte votre vie privée."),
+            "AtlasTracker est un traqueur de calories et de nutriments gratuit et open-source qui respecte votre vie privée."),
         "appLicenseLabel":
             MessageLookupByLibrary.simpleMessage("Licence GPL-3.0"),
-        "appTitle": MessageLookupByLibrary.simpleMessage("OpenNutriTracker"),
+        "appTitle": MessageLookupByLibrary.simpleMessage("AtlasTracker"),
         "appVersionName": m0,
         "averageWeightBody": MessageLookupByLibrary.simpleMessage(
             "Poids moyen de l\'utilisateur sur les sept derniers jours. Le jour courant n\'étant pas compté."),

--- a/lib/generated/intl/messages_tr.dart
+++ b/lib/generated/intl/messages_tr.dart
@@ -50,10 +50,10 @@ class MessageLookup extends MessageLookupByLibrary {
         "allItemsLabel": MessageLookupByLibrary.simpleMessage("Tümü"),
         "alphaVersionName": MessageLookupByLibrary.simpleMessage("[Alpha]"),
         "appDescription": MessageLookupByLibrary.simpleMessage(
-            "OpenNutriTracker, gizliliğinize saygı duyan ücretsiz ve açık kaynaklı bir kalori ve besin takipçisidir."),
+            "AtlasTracker, gizliliğinize saygı duyan ücretsiz ve açık kaynaklı bir kalori ve besin takipçisidir."),
         "appLicenseLabel":
             MessageLookupByLibrary.simpleMessage("GPL-3.0 lisansı"),
-        "appTitle": MessageLookupByLibrary.simpleMessage("OpenNutriTracker"),
+        "appTitle": MessageLookupByLibrary.simpleMessage("AtlasTracker"),
         "appVersionName": m0,
         "baseQuantityLabel":
             MessageLookupByLibrary.simpleMessage("Temel miktar (g/ml)"),

--- a/lib/generated/l10n.dart
+++ b/lib/generated/l10n.dart
@@ -50,10 +50,10 @@ class S {
     return Localizations.of<S>(context, S);
   }
 
-  /// `OpenNutriTracker`
+  /// `AtlasTracker`
   String get appTitle {
     return Intl.message(
-      'OpenNutriTracker',
+      'AtlasTracker',
       name: 'appTitle',
       desc: '',
       args: [],
@@ -70,10 +70,10 @@ class S {
     );
   }
 
-  /// `OpenNutriTracker is a free and open-source calorie and nutrient tracker that respects your privacy.`
+  /// `AtlasTracker is a free and open-source calorie and nutrient tracker that respects your privacy.`
   String get appDescription {
     return Intl.message(
-      'OpenNutriTracker is a free and open-source calorie and nutrient tracker that respects your privacy.',
+      'AtlasTracker is a free and open-source calorie and nutrient tracker that respects your privacy.',
       name: 'appDescription',
       desc: '',
       args: [],

--- a/lib/l10n/intl_de.arb
+++ b/lib/l10n/intl_de.arb
@@ -1,8 +1,8 @@
 {
   "coachStudentsLabel": "Meine Schüler",
-  "appTitle": "OpenNutriTracker",
+  "appTitle": "AtlasTracker",
   "appVersionName": "Version {versionNumber}",
-  "appDescription": "OpenNutriTracker ist ein kostenloser und  quelloffener Kalorien- und Nährstofftracker, der Ihre Privatsphäre respektiert.",
+  "appDescription": "AtlasTracker ist ein kostenloser und  quelloffener Kalorien- und Nährstofftracker, der Ihre Privatsphäre respektiert.",
   "alphaVersionName": "[Alpha]",
   "betaVersionName": "[Beta]",
   "addLabel": "Hinzufügen",

--- a/lib/l10n/intl_en.arb
+++ b/lib/l10n/intl_en.arb
@@ -1,7 +1,7 @@
 {
-  "appTitle": "OpenNutriTracker",
+  "appTitle": "AtlasTracker",
   "appVersionName": "Version {versionNumber}",
-  "appDescription": "OpenNutriTracker is a free and open-source calorie and nutrient tracker that respects your privacy.",
+  "appDescription": "AtlasTracker is a free and open-source calorie and nutrient tracker that respects your privacy.",
   "alphaVersionName": "[Alpha]",
   "averageWeightLabel": "Average Weight",
   "averageWeightBody": "Average user weight over the last seven days. The current day is not counted.",

--- a/lib/l10n/intl_fr.arb
+++ b/lib/l10n/intl_fr.arb
@@ -1,7 +1,7 @@
 {
-  "appTitle": "OpenNutriTracker",
+  "appTitle": "AtlasTracker",
   "appVersionName": "Version {versionNumber}",
-  "appDescription": "OpenNutriTracker est un traqueur de calories et de nutriments gratuit et open-source qui respecte votre vie privée.",
+  "appDescription": "AtlasTracker est un traqueur de calories et de nutriments gratuit et open-source qui respecte votre vie privée.",
   "alphaVersionName": "[Alpha]",
   "averageWeightLabel": "Poids moyen",
   "averageWeightBody": "Poids moyen de l'utilisateur sur les sept derniers jours. Le jour courant n'étant pas compté.",

--- a/lib/l10n/intl_tr.arb
+++ b/lib/l10n/intl_tr.arb
@@ -1,7 +1,7 @@
 {
-  "appTitle": "OpenNutriTracker",
+  "appTitle": "AtlasTracker",
   "appVersionName": "Versiyon {versionNumber}",
-  "appDescription": "OpenNutriTracker, gizliliğinize saygı duyan ücretsiz ve açık kaynaklı bir kalori ve besin takipçisidir.",
+  "appDescription": "AtlasTracker, gizliliğinize saygı duyan ücretsiz ve açık kaynaklı bir kalori ve besin takipçisidir.",
   "alphaVersionName": "[Alpha]",
   "betaVersionName": "[Beta]",
   "addLabel": "Ekle",

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -75,14 +75,14 @@ void runAppWithChangeNotifiers(bool userInitialized, bool hasAuthSession,
         AppThemeEntity savedAppTheme) =>
     runApp(ChangeNotifierProvider(
         create: (_) => ThemeModeProvider(appTheme: savedAppTheme),
-        child: OpenNutriTrackerApp(
+        child: AtlasTrackerApp(
             userInitialized: userInitialized, hasAuthSession: hasAuthSession)));
 
-class OpenNutriTrackerApp extends StatelessWidget {
+class AtlasTrackerApp extends StatelessWidget {
   final bool userInitialized;
   final bool hasAuthSession;
 
-  const OpenNutriTrackerApp({
+  const AtlasTrackerApp({
     super.key,
     required this.userInitialized,
     required this.hasAuthSession,

--- a/supabase/config.toml
+++ b/supabase/config.toml
@@ -2,7 +2,7 @@
 # https://supabase.com/docs/guides/local-development/cli/config
 # A string used to distinguish different Supabase projects on the same host. Defaults to the
 # working directory name when running `supabase init`.
-project_id = "OpenNutriTracker"
+project_id = "AtlasTracker"
 
 [api]
 enabled = true


### PR DESCRIPTION
## Summary
- rename OpenNutriTracker references to AtlasTracker across the project
- regenerate localization files

## Testing
- `flutter pub get`
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_688930893c5c8321bd0333577d28f10c