### PR TITLE
Delete local Hive DB when user account is removed

### DIFF
--- a/lib/core/utils/hive_db_provider.dart
+++ b/lib/core/utils/hive_db_provider.dart
@@ -196,6 +196,53 @@ class HiveDBProvider extends ChangeNotifier {
     ]);
   }
 
+  Future<void> _deleteBox(String baseName) async {
+    final name = _boxName(baseName);
+    if (await Hive.boxExists(name)) {
+      _log.finer('🗑️ Deleting box $name from disk');
+      await Hive.deleteBoxFromDisk(name);
+    }
+  }
+
+  /// Completely removes the Hive database for the current user from disk.
+  ///
+  /// All opened boxes are closed before deletion. After calling this method,
+  /// all local data for the user will be permanently deleted.
+  Future<void> deleteCurrentUserDatabase() async {
+    _log.info('🗑️ Deleting Hive database for user=$_userId');
+
+    // Ensure boxes are closed and watchers stopped
+    if (Hive.isBoxOpen(_boxName(configBoxName))) {
+      await trackedDayWatcher.stop();
+      await userWeightWatcher.stop();
+      await stopUpdateWatchers();
+
+      await Future.wait([
+        configBox.close(),
+        intakeBox.close(),
+        recipeBox.close(),
+        userActivityBox.close(),
+        userBox.close(),
+        trackedDayBox.close(),
+        userWeightBox.close(),
+        macroGoalBox.close(),
+      ]);
+    }
+
+    await Future.wait([
+      _deleteBox(configBoxName),
+      _deleteBox(intakeBoxName),
+      _deleteBox(userActivityBoxName),
+      _deleteBox(userBoxName),
+      _deleteBox(trackedDayBoxName),
+      _deleteBox(recipeBoxName),
+      _deleteBox(userWeightBoxName),
+      _deleteBox(macroGoalBoxName),
+    ]);
+
+    _log.info('✅ Hive database deleted for user=$_userId');
+  }
+
   /// Helper to (re)initialize Hive for the provided [userId].
   /// This fetches the encryption key from secure storage and delegates
   /// to [initHiveDB].

--- a/lib/features/profile/presentation/widgets/manage_account_dialog.dart
+++ b/lib/features/profile/presentation/widgets/manage_account_dialog.dart
@@ -5,6 +5,7 @@ import 'package:opennutritracker/generated/l10n.dart';
 import 'package:supabase_flutter/supabase_flutter.dart';
 import 'package:opennutritracker/features/auth/auth_safe_sign_out.dart';
 import 'package:opennutritracker/core/data/repository/config_repository.dart';
+import 'package:opennutritracker/core/utils/hive_db_provider.dart';
 
 class ManageAccountDialog extends StatefulWidget {
   const ManageAccountDialog({super.key});
@@ -111,6 +112,8 @@ class _ManageAccountDialogState extends State<ManageAccountDialog> {
       final response = await supabase.functions.invoke('delete_my_account');
 
       if (response.status == 200) {
+        final hive = locator<HiveDBProvider>();
+        await hive.deleteCurrentUserDatabase();
         if (mounted) {
           ScaffoldMessenger.of(context).showSnackBar(
             const SnackBar(content: Text("Account successfully deleted.")),


### PR DESCRIPTION
## Summary
- add `_deleteBox` as a helper to delete Hive boxes and call it from `deleteCurrentUserDatabase`
- ensure local Hive DB is removed on account deletion

## Testing
- `flutter analyze`
- `flutter test`


------
https://chatgpt.com/codex/tasks/task_e_688bb1ce7a308321884a27122484c99c